### PR TITLE
Reorder arguments to help avoid issues with --next

### DIFF
--- a/src/haxeLanguageServer/Context.hx
+++ b/src/haxeLanguageServer/Context.hx
@@ -351,17 +351,23 @@ class Context {
 		var actualArgs = [];
 		if (includeDisplayArguments) {
 			actualArgs = actualArgs.concat(["--cwd", workspacePath.toString()]);
-			if (config.displayArguments != null)
-				actualArgs = actualArgs.concat(config.displayArguments); // add arguments from the workspace settings
 			actualArgs = actualArgs.concat([
 				"-D",
 				"display-details", // get more details in completion results,
 				"--no-output", // prevent any generation
 			]);
 		}
+
+		// to avoid issues with --next we must
 		if (haxeServer.supports(HaxeMethods.Initialize) && config.user.enableServerView) {
-			actualArgs = actualArgs.concat(["--times", "-D", "macro-times"]);
+			actualArgs = ["--times", "-D", "macro-times"].concat(actualArgs);
 		}
+
+		// this must be the final argument before --display to avoid issues with --next
+		// see haxe issue #8795
+		if (includeDisplayArguments && config.displayArguments != null)
+			actualArgs = actualArgs.concat(config.displayArguments); // add arguments from the workspace settings
+
 		actualArgs.push("--display");
 		actualArgs = actualArgs.concat(args); // finally, add given query args
 		haxeServer.process(label, actualArgs, token, true, stdin, Processed(callback, errback));

--- a/src/haxeLanguageServer/server/HaxeServer.hx
+++ b/src/haxeLanguageServer/server/HaxeServer.hx
@@ -170,9 +170,8 @@ class HaxeServer {
 		startCompletionInitializationProgress("Building Cache");
 
 		/**
-			The following pattern may look like a mistake but it's a necessary trick for avoiding issues with hxmls that use --next
-			the first `--no-output --each` will apply --no-output to all the --next blocks, **unless** the user hxml itself include --each
-			in that case, the first `--no-output --each` will be ignored and replaced by the user's --each flags, so we need a second --no-output to be applied to the user's --each
+			The following pattern may look like a mistake but it's a necessary trick for avoiding issues with hxmls that use --next.
+			The first `--no-output --each` will apply `--no-output` to all the `--next` blocks, **unless** the user hxml itself include `--each`, in that case, the first `--no-output --each` will be ignored and replaced by the user's `--each` flags, so we need a second `--no-output` that gets added to the user's --eachh
 
 			See HaxeFoundation/haxe#8795
 		**/

--- a/src/haxeLanguageServer/server/HaxeServer.hx
+++ b/src/haxeLanguageServer/server/HaxeServer.hx
@@ -168,7 +168,9 @@ class HaxeServer {
 			return;
 
 		startCompletionInitializationProgress("Building Cache");
-		process("cache build", context.config.displayArguments.concat(["--no-output"]), null, true, null, Processed(function(_) {
+		// displayArguments must always be at the end of the argument list to avoid issues with --next
+		// see haxe issue #8795
+		process("cache build", ["--no-output"].concat(context.config.displayArguments), null, true, null, Processed(function(_) {
 			stopProgress();
 			if (supports(ServerMethods.ReadClassPaths)) {
 				readClassPaths();

--- a/src/haxeLanguageServer/server/HaxeServer.hx
+++ b/src/haxeLanguageServer/server/HaxeServer.hx
@@ -168,9 +168,18 @@ class HaxeServer {
 			return;
 
 		startCompletionInitializationProgress("Building Cache");
-		// displayArguments must always be at the end of the argument list to avoid issues with --next
-		// see haxe issue #8795
-		process("cache build", ["--no-output"].concat(context.config.displayArguments), null, true, null, Processed(function(_) {
+
+		/**
+			The following pattern may look like a mistake but it's a necessary trick for avoiding issues with hxmls that use --next
+			the first `--no-output --each` will apply --no-output to all the --next blocks, **unless** the user hxml itself include --each
+			in that case, the first `--no-output --each` will be ignored and replaced by the user's --each flags, so we need a second --no-output to be applied to the user's --each
+
+			See HaxeFoundation/haxe#8795
+		**/
+
+		var leadingArgs = ["--no-output", "--each", "--no-output"];
+
+		process("cache build", leadingArgs.concat(context.config.displayArguments), null, true, null, Processed(function(_) {
 			stopProgress();
 			if (supports(ServerMethods.ReadClassPaths)) {
 				readClassPaths();


### PR DESCRIPTION
This moves the display arguments like `--no-output` and `--cwd` to before the hxml file so that they're applied to the first compilation rather than the last when `--next` is used

This change is expected to have no impact when `--next` isn't used

Additionally, the following flags are prepended when building the compiler cache
`--no-output --each --no-output`. This trick is necessary to ensure `--no-output` is applied to each compilation set, whether or not the user's hxml includes `--each`.

How it works: the first `--no-output --each` will apply `--no-output` to all the `--next` blocks, **unless** the user hxml itself include `--each`, in that case, the first `--no-output --each` will be ignored and replaced by the user's `--each` flags, so we need a second `--no-output` that gets added to the user's --each