### PR TITLE
Unwrap Null<T> when extracting function signatures

### DIFF
--- a/src/haxeLanguageServer/protocol/DisplayPrinter.hx
+++ b/src/haxeLanguageServer/protocol/DisplayPrinter.hx
@@ -255,7 +255,11 @@ class DisplayPrinter {
 					case MethMacro: "macro ";
 				}
 				var finalKeyword = if (field.isFinalField()) "final " else "";
-				var definition = printEmptyFunctionDefinition(field.name, concreteType.extractFunctionSignature(), field.params);
+				if (occurrence.origin.isStructure() && field.meta.hasMeta(Optional)) {
+					name = "?" + name;
+				}
+				var methodSignature = concreteType.extractFunctionSignature();
+				var definition = printEmptyFunctionDefinition(name, methodSignature, field.params);
 				'$access$staticKeyword$finalKeyword$methodKind$definition';
 		};
 	}

--- a/src/haxeLanguageServer/protocol/Helper.hx
+++ b/src/haxeLanguageServer/protocol/Helper.hx
@@ -19,8 +19,8 @@ class Helper {
 	}
 
 	public static function extractFunctionSignature<T>(type:JsonType<T>) {
-		return switch type.kind {
-			case TFun: type.args;
+		return switch removeNulls(type).type {
+			case {kind: TFun, args: args}: args;
 			case _: throw "function expected";
 		}
 	}


### PR DESCRIPTION
Functions with `@:optional` metadata in structures have signatures wrapped in `Null<T>`. This change unwraps the Null when extracting the function signature and adds a `?` to the name to match the behavior of optional var fields

closes https://github.com/vshaxe/vshaxe/issues/409