### PR TITLE
Auto-import fix for vshaxe#414

### DIFF
--- a/src/haxeLanguageServer/helper/ImportHelper.hx
+++ b/src/haxeLanguageServer/helper/ImportHelper.hx
@@ -71,7 +71,7 @@ class ImportHelper {
 		var packageStatement = null;
 
 		// if the first token in the file is a comment, we should add the import after this
-		var firstComment = if (tokens.list[0].tok.match(Comment(_) | CommentLine(_))) {
+		var firstComment = if (tokens.list[0].tok.match(Comment(_))) {
 			tokens.list[0];
 		} else {
 			null;

--- a/src/haxeLanguageServer/helper/ImportHelper.hx
+++ b/src/haxeLanguageServer/helper/ImportHelper.hx
@@ -67,8 +67,15 @@ class ImportHelper {
 			return null;
 		}
 
-		var packageStatement = null;
 		var firstImport = null;
+		var packageStatement = null;
+
+		// if the first token in the file is a comment, we should add the import after this
+		var firstComment = if (tokens.list[0].tok.match(Comment(_) | CommentLine(_))) {
+			tokens.list[0];
+		} else {
+			null;
+		}
 
 		tokens.tree.filterCallback((tree, _) -> {
 			switch tree.tok {
@@ -97,11 +104,20 @@ class ImportHelper {
 				insertLineAfter: true,
 				insertLineBefore: true
 			}
+		} else if (firstComment != null) {
+			var pos = document.positionAt(firstComment.pos.max);
+			pos.line += 1;
+			pos.character = 0;
+			{
+				position: pos,
+				insertLineAfter: true,
+				insertLineBefore: true
+			}
 		} else {
 			{
 				position: {line: 0, character: 0},
-				insertLineAfter: false,
-				insertLineBefore: false
+				insertLineAfter: true,
+				insertLineBefore: true
 			}
 		}
 	}

--- a/test/haxeLanguageServer/helper/ImportHelperTest.hx
+++ b/test/haxeLanguageServer/helper/ImportHelperTest.hx
@@ -171,5 +171,32 @@ import Test;
 extern class WebSocket {}",
 
 		});
+
+		// issue #414 https://github.com/vshaxe/vshaxe/issues/414
+		// first import + meta with comment
+		test({
+			before: "
+package;
+
+@:keep // comment seems to affect this bug
+class Main {
+    static function main() {
+        
+    }
+}",
+
+			after: "
+package;
+
+import Test;
+
+@:keep // comment seems to affect this bug
+class Main {
+    static function main() {
+        
+    }
+}",
+
+		});
 	}
 }


### PR DESCRIPTION
When finding the position to add import statement vshaxe uses the position of the first type declaration
https://github.com/vshaxe/haxe-language-server/blob/a801ce6163e9a3c4c58b77cacb88aed30ac69dfb/src/haxeLanguageServer/helper/ImportHelper.hx#L91

This makes things complex because we have to consider tokens proceeding but part of the first type.

I'm not sure using the first type is an ideal approach, I think the expected behavior is to add the new import right after `package;` (if it exists). This PR replaces the first-type positioning behavior to position the first import after `package;`

Fixes https://github.com/vshaxe/vshaxe/issues/414

Regression test added