### PR TITLE
Fix jumbled synchronization between server and client

### DIFF
--- a/src/haxeLanguageServer/TextDocument.hx
+++ b/src/haxeLanguageServer/TextDocument.hx
@@ -44,6 +44,7 @@ class TextDocument {
 				var before = content.substring(0, offsetAt(event.range.start));
 				var after = content.substring(offsetAt(event.range.end));
 				content = before + event.text + after;
+				lineOffsets = null;
 			}
 		}
 		_parseTree = null;


### PR DESCRIPTION
`TextDocument.getLineOffsets()` recalculates offsets only if they're null, so the offsets weren't updating during the processing of `didChange` notification.
`TextDocument.offsetAt()` clamps the offset we want to write a character on in the range of `lineOffset` and `nextLineOffset` (which are unmodified by the previous operations in the same `update()` loop).

The edit reached the point where the line ended previously, it stayed there and wrote every following character at the same offset. So after reaching old end of line it started writing backwards.

This commit should solve it, although now the line offsets are
recalculated after every character when processing `textDocument/didChange`.
I didn't benchmark the slowdown but it seems minor enough.

Fixes vshaxe/vshaxe#376