### PR TITLE
Fix merging environment variables on Windows

### DIFF
--- a/src/haxeLanguageServer/server/HaxeServer.hx
+++ b/src/haxeLanguageServer/server/HaxeServer.hx
@@ -83,6 +83,15 @@ class HaxeServer {
 	function mergeEnvs(from:DynamicAccess<String>, to:DynamicAccess<String>) {
 		@:nullSafety(Off)
 		for (key => value in from) {
+			if (Sys.systemName() == "Windows") {
+				// compare case-insensitive, but preserve the original casing
+				for (initialKey => _ in to) {
+					if (key.toLowerCase() == initialKey.toLowerCase()) {
+						key = initialKey;
+						break;
+					}
+				}
+			}
 			to[key] = value;
 		}
 	}

--- a/src/haxeLanguageServer/server/HaxeServer.hx
+++ b/src/haxeLanguageServer/server/HaxeServer.hx
@@ -85,7 +85,7 @@ class HaxeServer {
 		for (key => value in from) {
 			if (Sys.systemName() == "Windows") {
 				// compare case-insensitive, but preserve the original casing
-				for (initialKey => _ in to) {
+				for (initialKey in to.keys()) {
 					if (key.toLowerCase() == initialKey.toLowerCase()) {
 						key = initialKey;
 						break;


### PR DESCRIPTION
Fix vshaxe/vshaxe#482 and vshaxe/vshaxe#486 by preserving the casing of the initial keys, as suggested in https://github.com/HaxeFoundation/haxe/issues/10151#issuecomment-789579064.