### PR TITLE
Fix "'uglifyjs' is not recognized" on Windows

### DIFF
--- a/src/haxeLanguageServer/Init.hx
+++ b/src/haxeLanguageServer/Init.hx
@@ -6,5 +6,5 @@ function run() {
 	#if debug
 	Compiler.define("uglifyjs_disabled");
 	#end
-	Compiler.define("uglifyjs_bin=" + (if (Sys.systemName() == "Windows") "node_modules\\.bin\\terser.cmd" else "./node_modules/.bin/terser"));
+	Compiler.define("uglifyjs_bin", (if (Sys.systemName() == "Windows") "node_modules\\.bin\\terser.cmd" else "./node_modules/.bin/terser"));
 }


### PR DESCRIPTION
Without this fix I am getting the following error when trying to build on Windows:
```
> npx lix run vshaxe-build -t language-server
'uglifyjs' is not recognized as an internal or external command,
operable program or batch file.
```