### PR TITLE
Properly announce prepareRename capability to LS client.

### DIFF
--- a/src/haxeLanguageServer/Context.hx
+++ b/src/haxeLanguageServer/Context.hx
@@ -244,7 +244,13 @@ class Context {
 		if (textDocument!.rename!.dynamicRegistration == true) {
 			register(RenameRequest.type, {documentSelector: haxeSelector, prepareProvider: true});
 		} else {
-			capabilities.renameProvider = true;
+			if (textDocument!.rename!.prepareSupport == true) {
+				capabilities.renameProvider = {
+					prepareProvider: true
+				};
+			} else {
+				capabilities.renameProvider = true;
+			}
 		}
 
 		if (textDocument!.foldingRange!.dynamicRegistration == true) {


### PR DESCRIPTION
Without this change clients don't know that the language server supports prepareRename.

The spec at https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#serverCapabilities says:
```typescript
/**
 * The server provides rename support. RenameOptions may only be
 * specified if the client states that it supports
 * `prepareSupport` in its initial `initialize` request.
 */
renameProvider?: boolean | RenameOptions;
```