### PR TITLE
Read document content from disk if not yet opened by client

### DIFF
--- a/src/haxeLanguageServer/documents/TextDocuments.hx
+++ b/src/haxeLanguageServer/documents/TextDocuments.hx
@@ -13,11 +13,23 @@ class TextDocuments {
 	}
 
 	public inline function getHaxe(uri:DocumentUri):Null<HaxeDocument> {
-		return @:nullSafety(Off) Std.downcast(documents[uri], HaxeDocument);
+		var doc:Null<HaxeDocument> = Std.downcast(documents[uri], HaxeDocument);
+		if (doc == null && uri.isHaxeFile()) {
+			// document not opened via client, load it directly from disk
+			// see https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didOpen
+			doc = new HaxeDocument(uri, "hx", 1, sys.io.File.getContent(uri.toFsPath().toString()));
+		}
+		return doc;
 	}
 
 	public inline function getHxml(uri:DocumentUri):Null<HxmlDocument> {
-		return @:nullSafety(Off) Std.downcast(documents[uri], HxmlDocument);
+		var doc:Null<HxmlDocument> = Std.downcast(documents[uri], HxmlDocument);
+		if (doc == null && uri.isHxmlFile()) {
+			// document not (yet) loaded via client, load it directly from disk
+			// see https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didOpen
+			doc = new HxmlDocument(uri, "hxml", 1, sys.io.File.getContent(uri.toFsPath().toString()));
+		}
+		return doc;
 	}
 
 	function onDidOpenTextDocument(event:DidOpenTextDocumentParams) {


### PR DESCRIPTION
Currently when an LSP client sends `textDocument/documentColor` for a document in the workspace that has not been announced via `textDocument/didOpen` the haxe language server returns the error `Unable to find document for URI file:///..., or feature is not supported for this file type / scheme`.

Following the spec as long as `textDocument/didOpen` was not send, the language server should directly read the content from disk: `Note that a server’s ability to fulfill requests is independent of whether a text document is open or closed.`, see https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didOpen
