### PR TITLE
Fix "[DEP0005] DeprecationWarning: Buffer() is deprecated"

### DIFF
--- a/src/haxeLanguageServer/helper/DisplayOffsetConverter.hx
+++ b/src/haxeLanguageServer/helper/DisplayOffsetConverter.hx
@@ -29,7 +29,7 @@ class Haxe3DisplayOffsetConverter extends DisplayOffsetConverter {
 	}
 
 	function byteOffsetToCharacterOffset(string:String, byteOffset:Int):Int {
-		final buf = new js.node.Buffer(string, "utf-8");
+		final buf = Buffer.from(string, "utf-8");
 		return buf.toString("utf-8", 0, byteOffset).length;
 	}
 


### PR DESCRIPTION
When starting the language server, the following warning is logged:
```js
(node:32096) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

This PR replaces the `new Buffer` call with `Buffer.from`.

Also see https://stackoverflow.com/questions/52165333/deprecationwarning-buffer-is-deprecated-due-to-security-and-usability-issues/52257416#52257416

