### PR TITLE
Don't return TextEdits if formatting changed nothing

### DIFF
--- a/src/haxeLanguageServer/features/haxe/DocumentFormattingFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/DocumentFormattingFeature.hx
@@ -69,9 +69,11 @@ class DocumentFormattingFeature {
 				} else {
 					range;
 				}
-				final edits = [{range: range, newText: formattedCode}];
-				resolve(edits);
-				onResolve(null, edits.length + " changes");
+				if (doc.getText(range) != formattedCode) {
+					final edits = [{range: range, newText: formattedCode}];
+					resolve(edits);
+					onResolve(null, edits.length + " changes");
+				}
 			case Failure(errorMessage):
 				reject(ResponseError.internalError(errorMessage));
 			case Disabled:


### PR DESCRIPTION
This prevents editors marking open files as changed once the format command was issued but nothing actually changed on document formatting.