### PR TITLE
Send empty TextEdit array if no changes occurred during format request

### DIFF
--- a/src/haxeLanguageServer/features/haxe/DocumentFormattingFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/DocumentFormattingFeature.hx
@@ -69,11 +69,9 @@ class DocumentFormattingFeature {
 				} else {
 					range;
 				}
-				if (doc.getText(range) != formattedCode) {
-					final edits = [{range: range, newText: formattedCode}];
-					resolve(edits);
-					onResolve(null, edits.length + " changes");
-				}
+				final edits = if (doc.getText(range) != formattedCode) [{range: range, newText: formattedCode}] else [];
+				resolve(edits);
+				onResolve(null, edits.length + " changes");
 			case Failure(errorMessage):
 				reject(ResponseError.internalError(errorMessage));
 			case Disabled:


### PR DESCRIPTION
With my last PR, no response was send to the LS client. This PR changes it so that an empty response is send to allow clients properly finish the request/response cycle.