### PR TITLE
Fix LSP for documents with surrogates pairs

### DIFF
--- a/src/haxeLanguageServer/features/haxe/DiagnosticsFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/DiagnosticsFeature.hx
@@ -175,7 +175,7 @@ class DiagnosticsFeature {
 						end: {line: 0, character: 0}
 					}
 				} else {
-					hxDiag.range;
+					context.displayOffsetConverter.byteRangeToCharacterRange(hxDiag.range, doc);
 				};
 				final diag:Diagnostic = {
 					range: range,

--- a/src/haxeLanguageServer/features/haxe/FindReferencesFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/FindReferencesFeature.hx
@@ -22,7 +22,8 @@ class FindReferencesFeature {
 			return reject.noFittingDocument(uri);
 		}
 		final handle = if (context.haxeServer.supports(DisplayMethods.FindReferences)) handleJsonRpc else handleLegacy;
-		handle(params, token, resolve, reject, doc, doc.offsetAt(params.position));
+		final offset = context.displayOffsetConverter.characterOffsetToByteOffset(doc.content, doc.offsetAt(params.position));
+		handle(params, token, resolve, reject, doc, offset);
 	}
 
 	function handleJsonRpc(params:TextDocumentPositionParams, token:CancellationToken, resolve:Null<Array<Location>>->Void,
@@ -45,8 +46,7 @@ class FindReferencesFeature {
 
 	function handleLegacy(params:TextDocumentPositionParams, token:CancellationToken, resolve:Null<Array<Location>>->Void, reject:ResponseError<NoData>->Void,
 			doc:HxTextDocument, offset:Int) {
-		final bytePos = context.displayOffsetConverter.characterOffsetToByteOffset(doc.content, doc.offsetAt(params.position));
-		final args = ['${doc.uri.toFsPath()}@$bytePos@usage'];
+		final args = ['${doc.uri.toFsPath()}@$offset@usage'];
 		context.callDisplay("@usage", args, doc.content, token, function(r) {
 			switch r {
 				case DCancelled:

--- a/src/haxeLanguageServer/features/haxe/GotoDefinitionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/GotoDefinitionFeature.hx
@@ -22,7 +22,8 @@ class GotoDefinitionFeature {
 			return reject.noFittingDocument(uri);
 		}
 		final handle = if (context.haxeServer.supports(DisplayMethods.GotoDefinition)) handleJsonRpc else handleLegacy;
-		handle(params, token, resolve, reject, doc, doc.offsetAt(params.position));
+		final offset = context.displayOffsetConverter.characterOffsetToByteOffset(doc.content, doc.offsetAt(params.position));
+		handle(params, token, resolve, reject, doc, offset);
 	}
 
 	function handleJsonRpc(params:TextDocumentPositionParams, token:CancellationToken, resolve:Array<DefinitionLink>->Void,
@@ -68,8 +69,7 @@ class GotoDefinitionFeature {
 
 	function handleLegacy(params:TextDocumentPositionParams, token:CancellationToken, resolve:Array<DefinitionLink>->Void, reject:ResponseError<NoData>->Void,
 			doc:HxTextDocument, offset:Int) {
-		final bytePos = context.displayOffsetConverter.characterOffsetToByteOffset(doc.content, offset);
-		final args = ['${doc.uri.toFsPath()}@$bytePos@position'];
+		final args = ['${doc.uri.toFsPath()}@$offset@position'];
 		context.callDisplay("@position", args, doc.content, token, function(r) {
 			switch r {
 				case DCancelled:

--- a/src/haxeLanguageServer/features/haxe/GotoImplementationFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/GotoImplementationFeature.hx
@@ -21,7 +21,8 @@ class GotoImplementationFeature {
 		if (doc == null || !uri.isFile()) {
 			return reject.noFittingDocument(uri);
 		}
-		handleJsonRpc(params, token, resolve, reject, doc, doc.offsetAt(params.position));
+		final offset = context.displayOffsetConverter.characterOffsetToByteOffset(doc.content, doc.offsetAt(params.position));
+		handleJsonRpc(params, token, resolve, reject, doc, offset);
 	}
 
 	function handleJsonRpc(params:TextDocumentPositionParams, token:CancellationToken, resolve:Definition->Void, reject:ResponseError<NoData>->Void,

--- a/src/haxeLanguageServer/features/haxe/GotoTypeDefinitionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/GotoTypeDefinitionFeature.hx
@@ -21,7 +21,8 @@ class GotoTypeDefinitionFeature {
 		if (doc == null || !uri.isFile()) {
 			return reject.noFittingDocument(uri);
 		}
-		context.callHaxeMethod(DisplayMethods.GotoTypeDefinition, {file: uri.toFsPath(), contents: doc.content, offset: doc.offsetAt(params.position)}, token,
+		final offset = context.displayOffsetConverter.characterOffsetToByteOffset(doc.content, doc.offsetAt(params.position));
+		context.callHaxeMethod(DisplayMethods.GotoTypeDefinition, {file: uri.toFsPath(), contents: doc.content, offset: offset}, token,
 			locations -> {
 				resolve(locations.map(location -> {
 					{

--- a/src/haxeLanguageServer/features/haxe/HoverFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/HoverFeature.hx
@@ -34,25 +34,7 @@ class HoverFeature {
 			if (hover == null) {
 				resolve(null);
 			} else {
-				final range:Range = {
-					final startPosition = {
-						line: hover.range.start.line,
-						character: context.displayOffsetConverter.byteOffsetToCharacterOffset(
-							doc.lineAt(hover.range.start.line),
-							hover.range.start.character
-						)
-					}
-
-					final endPosition = {
-						line: hover.range.end.line,
-						character: context.displayOffsetConverter.byteOffsetToCharacterOffset(
-							doc.lineAt(hover.range.end.line),
-							hover.range.end.character
-						)
-					};
-
-					{start: startPosition, end: endPosition};
-				};
+				final range = context.displayOffsetConverter.byteRangeToCharacterRange(hover.range, doc);
 				resolve(createHover(printContent(doc, hover), hover.item.getDocumentation(), range));
 			}
 			return null;

--- a/src/haxeLanguageServer/features/haxe/HoverFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/HoverFeature.hx
@@ -34,23 +34,22 @@ class HoverFeature {
 			if (hover == null) {
 				resolve(null);
 			} else {
-				// Fixup range if line contains surrogates
 				final range:Range = {
-					final startPosition = doc.positionAt(doc.offsetAt(hover.range.start));
-					final endPosition = doc.positionAt(doc.offsetAt(hover.range.end));
-					final endCharacter = endPosition.character;
+					final startPosition = {
+						line: hover.range.start.line,
+						character: context.displayOffsetConverter.byteOffsetToCharacterOffset(
+							doc.lineAt(hover.range.start.line),
+							hover.range.start.character
+						)
+					}
 
-					endPosition.character = context.displayOffsetConverter.byteOffsetToCharacterOffset(
-						doc.lineAt(startPosition.line),
-						endPosition.character
-					);
-
-					startPosition.character = startPosition.line == endPosition.line
-						? endPosition.character - (endCharacter - startPosition.character)
-						: context.displayOffsetConverter.byteOffsetToCharacterOffset(
-							doc.lineAt(startPosition.line),
-							startPosition.character
-						);
+					final endPosition = {
+						line: hover.range.end.line,
+						character: context.displayOffsetConverter.byteOffsetToCharacterOffset(
+							doc.lineAt(hover.range.end.line),
+							hover.range.end.character
+						)
+					};
 
 					{start: startPosition, end: endPosition};
 				};

--- a/src/haxeLanguageServer/features/haxe/HoverFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/HoverFeature.hx
@@ -24,7 +24,8 @@ class HoverFeature {
 			return reject.noFittingDocument(uri);
 		}
 		final handle = if (context.haxeServer.supports(DisplayMethods.Hover)) handleJsonRpc else handleLegacy;
-		handle(params, token, resolve, reject, doc, doc.offsetAt(params.position));
+		final offset = context.displayOffsetConverter.characterOffsetToByteOffset(doc.content, doc.offsetAt(params.position));
+		handle(params, token, resolve, reject, doc, offset);
 	}
 
 	function handleJsonRpc(params:TextDocumentPositionParams, token:CancellationToken, resolve:Null<Hover>->Void, reject:ResponseError<NoData>->Void,
@@ -115,8 +116,7 @@ class HoverFeature {
 
 	function handleLegacy(params:TextDocumentPositionParams, token:CancellationToken, resolve:Null<Hover>->Void, reject:ResponseError<NoData>->Void,
 			doc:HxTextDocument, offset:Int) {
-		final bytePos = context.displayOffsetConverter.characterOffsetToByteOffset(doc.content, offset);
-		final args = ['${doc.uri.toFsPath()}@$bytePos@type'];
+		final args = ['${doc.uri.toFsPath()}@$offset@type'];
 		context.callDisplay("@type", args, doc.content, token, function(result) {
 			switch result {
 				case DCancelled:

--- a/src/haxeLanguageServer/features/haxe/SignatureHelpFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/SignatureHelpFeature.hx
@@ -48,7 +48,7 @@ class SignatureHelpFeature {
 		final params = {
 			file: doc.uri.toFsPath(),
 			contents: doc.content,
-			offset: doc.offsetAt(params.position),
+			offset: context.displayOffsetConverter.characterOffsetToByteOffset(doc.content, doc.offsetAt(params.position)),
 			wasAutoTriggered: wasAutoTriggered
 		}
 		context.callHaxeMethod(DisplayMethods.SignatureHelp, params, token, function(result) {

--- a/src/haxeLanguageServer/features/haxe/completion/CompletionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/completion/CompletionFeature.hx
@@ -171,7 +171,7 @@ class CompletionFeature {
 		final haxeParams:HaxeCompletionParams = {
 			file: doc.uri.toFsPath(),
 			contents: doc.content,
-			offset: offset,
+			offset: context.displayOffsetConverter.characterOffsetToByteOffset(doc.content, offset),
 			wasAutoTriggered: wasAutoTriggered,
 			meta: [CompilerMetadata.Deprecated]
 		};

--- a/src/haxeLanguageServer/helper/DisplayOffsetConverter.hx
+++ b/src/haxeLanguageServer/helper/DisplayOffsetConverter.hx
@@ -14,6 +14,25 @@ abstract class DisplayOffsetConverter {
 		return if (haxeVersion >= new SemVer(4, 0, 0)) new Haxe4DisplayOffsetConverter() else new Haxe3DisplayOffsetConverter();
 	}
 
+	public function byteRangeToCharacterRange(range:Range, doc:HxTextDocument):Range {
+		return {
+			start: {
+				line: range.start.line,
+				character: byteOffsetToCharacterOffset(
+					doc.lineAt(range.start.line),
+					range.start.character
+				)
+			},
+			end: {
+				line: range.end.line,
+				character: byteOffsetToCharacterOffset(
+					doc.lineAt(range.end.line),
+					range.end.character
+				)
+			}
+		};
+	}
+
 	public abstract function positionCharToZeroBasedColumn(char:Int):Int;
 
 	public abstract function byteOffsetToCharacterOffset(string:String, byteOffset:Int):Int;

--- a/src/haxeLanguageServer/helper/DisplayOffsetConverter.hx
+++ b/src/haxeLanguageServer/helper/DisplayOffsetConverter.hx
@@ -50,11 +50,22 @@ class Haxe4DisplayOffsetConverter extends DisplayOffsetConverter {
 		return char - 1;
 	}
 
-	function byteOffsetToCharacterOffset(_, offset:Int):Int {
-		return offset;
+	function byteOffsetToCharacterOffset(string:String, offset:Int):Int {
+		return inline offsetSurrogates(string, offset, 1);
 	}
 
-	function characterOffsetToByteOffset(_, offset:Int):Int {
-		return offset;
+	function characterOffsetToByteOffset(string:String, offset:Int):Int {
+		return inline offsetSurrogates(string, offset, -1);
+	}
+
+	function offsetSurrogates(string:String, offset:Int, direction:Int):Int {
+		var ret = offset;
+		var i = 0;
+		while (i < string.length && i < offset) {
+			var ch = string.charCodeAt(i).sure();
+			if (ch > 0xD800 && ch < 0xDC00) ret += direction;
+			i++;
+		}
+		return ret;
 	}
 }

--- a/src/haxeLanguageServer/helper/DisplayOffsetConverter.hx
+++ b/src/haxeLanguageServer/helper/DisplayOffsetConverter.hx
@@ -79,11 +79,14 @@ class Haxe4DisplayOffsetConverter extends DisplayOffsetConverter {
 
 	function offsetSurrogates(string:String, offset:Int, direction:Int):Int {
 		var ret = offset;
-		var i = 0;
-		while (i < string.length && i < offset) {
-			var ch = string.charCodeAt(i).sure();
-			if (ch > 0xD800 && ch < 0xDC00) ret += direction;
-			i++;
+		var i = 0, j = 0;
+		while (j < string.length && i < offset) {
+			var ch = string.charCodeAt(j).sure();
+			if (ch >= 0xD800 && ch < 0xDC00) {
+				ret += direction;
+				j++;
+			}
+			i++; j++;
 		}
 		return ret;
 	}


### PR DESCRIPTION
Currently, Haxe LSP doesn't work well with surrogate pairs:

![Recording 2023-01-24 at 11 58 31](https://user-images.githubusercontent.com/6101998/214274551-9ef00944-d31e-4dc3-a684-ecdf51b011b3.gif)

Fixes https://github.com/vshaxe/vshaxe/issues/546
Fixes https://github.com/vshaxe/vshaxe/issues/343

* [x] Fix completion requests after surrogate pairs
* [x] Fix hover requests after surrogate pairs
* [x] Fix hover requests after surrogate pairs (same line)
* [x] Fix hover requests _including_ surrogate pairs 
* [x] Don't let diagnostics break above two points...
* [x] Identify and fix other kind of requests (go to definition, find references, etc.)
* [x] Double check that Haxe LSP still works fine with other kind of documents, and Haxe 3.x

Current state with this PR:

![Recording 2023-01-24 at 16 46 43](https://user-images.githubusercontent.com/6101998/214340430-7b88b87e-5f12-4dfd-b1b1-4316ded79599.gif)