### PR TITLE
Fix fully qualified completion on new foo.bar.X

### DIFF
--- a/src/haxeLanguageServer/features/haxe/completion/CompletionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/completion/CompletionFeature.hx
@@ -238,7 +238,7 @@ class CompletionFeature {
 			final importPosition = determineImportPosition(doc);
 			final indent = doc.indentAt(params.position.line);
 			// the replaceRanges sent by Haxe are only trustworthy in some cases (https://github.com/HaxeFoundation/haxe/issues/8669)
-			if (mode == Metadata || mode == Toplevel) {
+			if (mode == Metadata || mode == Toplevel || mode == New) {
 				if (result.replaceRange != null) {
 					replaceRange = result.replaceRange;
 				}


### PR DESCRIPTION
When `haxe.codeGeneration.imports.enableAutoImports` is set to `false` and starting completion on an already typed full path for a `new` expression (for example `new haxe.xml.|`) and selecting a completion item, replace range is wrong.

Before:
![Recording 2023-01-24 at 17 35 17](https://user-images.githubusercontent.com/6101998/214353426-986d7a05-fad0-4d8f-84d6-992775e8feb2.gif)

After:
![Recording 2023-01-24 at 17 36 47](https://user-images.githubusercontent.com/6101998/214353452-948d918a-a84a-467d-96e7-75bcafd85e86.gif)
