### PR TITLE
Replace path range instead of word range for some modes

### DIFF
--- a/src/haxeLanguageServer/features/haxe/completion/CompletionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/completion/CompletionFeature.hx
@@ -237,11 +237,18 @@ class CompletionFeature {
 			}
 			final importPosition = determineImportPosition(doc);
 			final indent = doc.indentAt(params.position.line);
-			// the replaceRanges sent by Haxe are only trustworthy in some cases (https://github.com/HaxeFoundation/haxe/issues/8669)
-			if (mode == Metadata || mode == Toplevel || mode == New) {
-				if (result.replaceRange != null) {
+
+			switch (mode) {
+				// the replaceRanges sent by Haxe are only trustworthy in some cases (https://github.com/HaxeFoundation/haxe/issues/8669)
+				case Metadata | Toplevel if (result.replaceRange != null):
 					replaceRange = result.replaceRange;
-				}
+
+				case New | Toplevel:
+					final pathPattern = ~/\w+(\.\w+)*$/;
+					pathPattern.match(textBefore);
+					replaceRange.start = params.position.translate(0, -pathPattern.matched(0).length);
+
+				case _:
 			}
 
 			final displayItems = result.items;

--- a/src/haxeLanguageServer/features/haxe/completion/CompletionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/completion/CompletionFeature.hx
@@ -243,7 +243,7 @@ class CompletionFeature {
 				case Metadata | Toplevel if (result.replaceRange != null):
 					replaceRange = result.replaceRange;
 
-				case New | Toplevel:
+				case New | Toplevel | TypeHint | TypeRelation:
 					final pathPattern = ~/\w+(\.\w+)*$/;
 					pathPattern.match(textBefore);
 					replaceRange.start = params.position.translate(0, -pathPattern.matched(0).length);

--- a/src/haxeLanguageServer/features/haxe/completion/CompletionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/completion/CompletionFeature.hx
@@ -243,7 +243,7 @@ class CompletionFeature {
 				case Metadata | Toplevel if (result.replaceRange != null):
 					replaceRange = result.replaceRange;
 
-				case New | Toplevel | TypeHint | TypeRelation:
+				case New | Toplevel | Implements | Extends | TypeHint | TypeRelation:
 					final pathPattern = ~/\w+(\.\w+)*$/;
 					pathPattern.match(textBefore);
 					replaceRange.start = params.position.translate(0, -pathPattern.matched(0).length);

--- a/src/haxeLanguageServer/features/haxe/completion/CompletionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/completion/CompletionFeature.hx
@@ -245,8 +245,9 @@ class CompletionFeature {
 
 				case New | Toplevel | Implements | Extends | TypeHint | TypeRelation:
 					final pathPattern = ~/\w+(\.\w+)*$/;
-					pathPattern.match(textBefore);
-					replaceRange.start = params.position.translate(0, -pathPattern.matched(0).length);
+					if (pathPattern.match(textBefore)) {
+						replaceRange.start = params.position.translate(0, -pathPattern.matched(0).length);
+					}
 
 				case _:
 			}


### PR DESCRIPTION
#77 was breaking `new B|<String, String>();` use case:
![Recording 2023-01-25 at 11 06 23](https://user-images.githubusercontent.com/6101998/214535945-596256a1-e731-4eff-8695-f73819645cac.gif)

With this version:
![Recording 2023-01-25 at 11 08 19](https://user-images.githubusercontent.com/6101998/214535970-1e9818a4-7a5d-4084-acb4-2c7e1b469e7d.gif)
![Recording 2023-01-25 at 11 09 19](https://user-images.githubusercontent.com/6101998/214535979-46521cad-dc47-4dae-a277-c89f5a9d3fee.gif)


Update:  I noticed some other cases had the original issue:
![Recording 2023-01-25 at 11 27 17](https://user-images.githubusercontent.com/6101998/214540841-0bf9cf35-ba99-4371-9512-e43501e03313.gif)

So I added `TypeHint`, `TypeRelation`, and also (but not recorded) `Implements` and `Extends` to modes using path replace range:
![Recording 2023-01-25 at 11 24 36](https://user-images.githubusercontent.com/6101998/214540969-6398c95f-17f0-473d-b71e-9a06729952e5.gif)

