### PR TITLE
Don't trigger type param snippet when type params already present

### DIFF
--- a/src/haxeLanguageServer/features/haxe/completion/CompletionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/completion/CompletionFeature.hx
@@ -609,7 +609,8 @@ class CompletionFeature {
 
 		if (snippetSupport) {
 			switch data.mode.kind {
-				case TypeHint | Extends | Implements | StructExtension if (type.hasMandatoryTypeParameters()):
+				case TypeHint | Extends | Implements | StructExtension
+				if (data.lineAfter.charCodeAt(0) != '<'.code && type.hasMandatoryTypeParameters()):
 					textEdit.newText += "<$1>";
 					item.insertTextFormat = Snippet;
 					item.command = TriggerSuggest;


### PR DESCRIPTION
Fixes https://github.com/vshaxe/vshaxe/issues/469

It won't prevent the issue from happening if there's whitespace between completion and type parameters, but it seems ok to me?