### PR TITLE
Location objects can be null in display requests

### DIFF
--- a/src/haxeLanguageServer/features/haxe/FindReferencesFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/FindReferencesFeature.hx
@@ -34,12 +34,17 @@ class FindReferencesFeature {
 			offset: offset,
 			kind: WithBaseAndDescendants
 		}, token, locations -> {
-			resolve(locations.filter(location -> location != null).map(location -> {
-				{
-					uri: location.file.toUri(),
-					range: location.range
+			resolve([
+				for (location in locations) {
+					if (location == null)
+						continue;
+
+					{
+						uri: location.file.toUri(),
+						range: location.range
+					}
 				}
-			}));
+			]);
 			return null;
 		}, reject.handler());
 	}

--- a/src/haxeLanguageServer/features/haxe/GotoDefinitionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/GotoDefinitionFeature.hx
@@ -33,24 +33,31 @@ class GotoDefinitionFeature {
 			contents: doc.content,
 			offset: offset
 		}, token, function(locations) {
-			resolve(locations.map(location -> {
-				final document = getHaxeDocument(location.file.toUri());
-				final tokens = document!.tokens;
-				var previewDeclarationRange = location.range;
-				if (document != null && tokens != null) {
-					final targetToken = tokens!.getTokenAtOffset(document.offsetAt(location.range.start));
-					final pos = targetToken!.parent!.getPos();
-					if (pos != null)
-						previewDeclarationRange = document.rangeAt(pos.min, pos.max);
-				}
+			resolve([
+				for (location in locations) {
+					if (location == null)
+						continue;
 
-				final link:DefinitionLink = {
-					targetUri: location.file.toUri(),
-					targetRange: previewDeclarationRange,
-					targetSelectionRange: location.range,
-				};
-				link;
-			}));
+					final document = getHaxeDocument(location.file.toUri());
+					final tokens = document!.tokens;
+					var previewDeclarationRange = location.range;
+					if (document != null && tokens != null) {
+						final targetToken = tokens!.getTokenAtOffset(document.offsetAt(location.range.start));
+						final pos = targetToken!.parent!.getPos();
+						if (pos != null)
+							previewDeclarationRange = document.rangeAt(pos.min, pos.max);
+					}
+
+					final link:DefinitionLink = {
+						targetUri: location.file.toUri(),
+						targetRange: previewDeclarationRange,
+						targetSelectionRange: location.range,
+					};
+
+					link;
+				}
+			]);
+
 			return null;
 		}, reject.handler());
 	}

--- a/src/haxeLanguageServer/features/haxe/GotoImplementationFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/GotoImplementationFeature.hx
@@ -28,12 +28,17 @@ class GotoImplementationFeature {
 	function handleJsonRpc(params:TextDocumentPositionParams, token:CancellationToken, resolve:Definition->Void, reject:ResponseError<NoData>->Void,
 			doc:HxTextDocument, offset:Int) {
 		context.callHaxeMethod(DisplayMethods.GotoImplementation, {file: doc.uri.toFsPath(), contents: doc.content, offset: offset}, token, locations -> {
-			resolve(locations.map(location -> {
-				{
-					uri: location.file.toUri(),
-					range: location.range
+			resolve([
+				for (location in locations) {
+					if (location == null)
+						continue;
+
+					{
+						uri: location.file.toUri(),
+						range: location.range
+					}
 				}
-			}));
+			]);
 			return null;
 		}, reject.handler());
 	}

--- a/src/haxeLanguageServer/features/haxe/GotoTypeDefinitionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/GotoTypeDefinitionFeature.hx
@@ -23,12 +23,17 @@ class GotoTypeDefinitionFeature {
 		}
 		final offset = context.displayOffsetConverter.characterOffsetToByteOffset(doc.content, doc.offsetAt(params.position));
 		context.callHaxeMethod(DisplayMethods.GotoTypeDefinition, {file: uri.toFsPath(), contents: doc.content, offset: offset}, token, locations -> {
-			resolve(locations.map(location -> {
-				{
-					uri: location.file.toUri(),
-					range: location.range
+			resolve([
+				for (location in locations) {
+					if (location == null)
+						continue;
+
+					{
+						uri: location.file.toUri(),
+						range: location.range
+					}
 				}
-			}));
+			]);
 			return null;
 		}, reject.handler());
 	}


### PR DESCRIPTION
This can lead to `Cannot read properties of null (reading 'file')` errors in some cases.
While such cases might be worth investigating as to why they're getting `null_pos` in the first place, these could be legitimate and/or at least shouldn't break this way for users. 

See:
 * https://github.com/HaxeFoundation/haxe/commit/737a82f4341547e3a4981a0c993493ae73260cc2
 * https://github.com/HaxeFoundation/haxe/blob/development/src/core/json/genjson.ml#L119