### PR TITLE
Sort anon fields (fixes @:structInit fields generation order)

### DIFF
--- a/src/haxeLanguageServer/features/haxe/completion/ExpectedTypeCompletion.hx
+++ b/src/haxeLanguageServer/features/haxe/completion/ExpectedTypeCompletion.hx
@@ -103,6 +103,7 @@ class ExpectedTypeCompletion {
 			case TAnonymous:
 				// TODO: support @:structInit
 				final anon = concreteType.args;
+				anon.fields.sort((f1, f2) -> f1.name < f2.name ? -1 : 1);
 				final singleLine = data.mode.kind == Pattern;
 				final allFields = printer.printObjectLiteral(anon, singleLine, false, true);
 				final requiredFields = printer.printObjectLiteral(anon, singleLine, true, true);


### PR DESCRIPTION
Currently, completion on `var foo:Foo = |` for `@:structInit class Foo { ... }` generates an object with fields in reverse order.

Sorting fields there does fix the issue, however I'm not sure if there would be cases where we would _not_ want anon fields to be sorted for such completion?

(also, comment on line 104 doesn't seem needed anymore?)