### PR TITLE
Only call server/invalidate once per file between compilations

### DIFF
--- a/src/haxeLanguageServer/Context.hx
+++ b/src/haxeLanguageServer/Context.hx
@@ -387,10 +387,7 @@ class Context {
 	function onDidChangeTextDocument(event:DidChangeTextDocumentParams) {
 		final uri = event.textDocument.uri;
 		if (isUriSupported(uri)) {
-			if (!invalidated.exists(uri.toString())) {
-				callFileParamsMethod(uri, ServerMethods.Invalidate);
-				invalidated.set(uri.toString(), true);
-			}
+			invalidateFile(uri);
 			documents.onDidChangeTextDocument(event);
 		}
 	}
@@ -407,6 +404,7 @@ class Context {
 		final uri = event.textDocument.uri;
 		if (isUriSupported(uri)) {
 			publishDiagnostics(uri);
+			invalidated.remove(uri.toString());
 		}
 	}
 
@@ -417,12 +415,16 @@ class Context {
 					callFileParamsMethod(change.uri, ServerMethods.ModuleCreated);
 				case Deleted:
 					diagnostics.clearDiagnostics(change.uri);
-					if (!invalidated.exists(change.uri.toString())) {
-						callFileParamsMethod(change.uri, ServerMethods.Invalidate);
-						invalidated.set(change.uri.toString(), true);
-					}
+					invalidateFile(change.uri);
 				case _:
 			}
+		}
+	}
+
+	function invalidateFile(uri:DocumentUri) {
+		if (!invalidated.exists(uri.toString())) {
+			callFileParamsMethod(uri, ServerMethods.Invalidate);
+			invalidated.set(uri.toString(), true);
 		}
 	}
 

--- a/src/haxeLanguageServer/server/HaxeServer.hx
+++ b/src/haxeLanguageServer/server/HaxeServer.hx
@@ -290,6 +290,7 @@ class HaxeServer {
 					socket.destroy();
 					trace("Client disconnected");
 				}
+				context.resetInvalidatedFiles();
 				process("compilation", split, null, false, null, Raw(callback));
 			});
 			socket.on(SocketEvent.Error, function(err) {


### PR DESCRIPTION
Fixes https://github.com/vshaxe/vshaxe/issues/439

Also fixes these kind of situations:
![image](https://user-images.githubusercontent.com/6101998/220586959-a8a2a4b9-24ca-4408-ba09-4ff4ba7c6f8e.png)

_(`server/invalidate` requests taking ~1.4s are compilation server GC runs, which would happen a lot less without these requests)_