### PR TITLE
Add argument action

### DIFF
--- a/shared/haxeLanguageServer/LanguageServerMethods.hx
+++ b/shared/haxeLanguageServer/LanguageServerMethods.hx
@@ -84,6 +84,11 @@ class LanguageServerMethods {
 		This request is sent from the client to the server to export current server recording.
 	**/
 	static inline final ExportServerRecording = new RequestType<Null<{dest:String}>, String, String>("haxe/exportServerRecording");
+
+	/**
+		This notification is sent from the server to the client to execute command on client.
+	**/
+	static inline final ExecuteClientCommand = new NotificationType<{command:String, arguments:Array<Any>}>("haxe/executeClientCommand");
 }
 
 typedef MethodResult = {

--- a/src/haxeLanguageServer/features/haxe/GotoDefinitionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/GotoDefinitionFeature.hx
@@ -10,8 +10,10 @@ import languageServerProtocol.Types.DefinitionLink;
 class GotoDefinitionFeature {
 	final context:Context;
 
-	public function new(context) {
+	public function new(context, listen = true) {
 		this.context = context;
+		if (!listen)
+			return;
 		context.languageServerProtocol.onRequest(DefinitionRequest.type, onGotoDefinition);
 	}
 

--- a/src/haxeLanguageServer/features/haxe/GotoDefinitionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/GotoDefinitionFeature.hx
@@ -10,10 +10,8 @@ import languageServerProtocol.Types.DefinitionLink;
 class GotoDefinitionFeature {
 	final context:Context;
 
-	public function new(context, listen = true) {
+	public function new(context) {
 		this.context = context;
-		if (!listen)
-			return;
 		context.languageServerProtocol.onRequest(DefinitionRequest.type, onGotoDefinition);
 	}
 

--- a/src/haxeLanguageServer/features/haxe/InlayHintFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/InlayHintFeature.hx
@@ -292,7 +292,7 @@ class InlayHintFeature {
 		if (pOpen.access().parent().matches(Kwd(KwdNew)).exists()) {
 			return promises;
 		}
-		var pClose:Null<TokenTree> = pOpen.access().firstOf(PClose).token;
+		var pClose:Null<TokenTree> = pOpen.access().firstOf(PClose)!.token;
 		if (pClose == null) {
 			return promises;
 		}

--- a/src/haxeLanguageServer/features/haxe/codeAction/CodeActionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/CodeActionFeature.hx
@@ -1,5 +1,6 @@
 package haxeLanguageServer.features.haxe.codeAction;
 
+import js.lib.Promise;
 import jsonrpc.CancellationToken;
 import jsonrpc.ResponseError;
 import jsonrpc.Types.NoData;
@@ -9,8 +10,13 @@ interface CodeActionContributor {
 	function createCodeActions(params:CodeActionParams):Array<CodeAction>;
 }
 
+enum CodeActionResolveData {
+	MissingArg(callback:(action:CodeAction) -> Null<Promise<CodeAction>>);
+}
+
 class CodeActionFeature {
 	public static inline final SourceSortImports = "source.sortImports";
+	static final resolveCallbacks:Array<Null<CodeActionResolveData>> = [];
 
 	final context:Context;
 	final contributors:Array<CodeActionContributor> = [];
@@ -20,9 +26,11 @@ class CodeActionFeature {
 
 		context.registerCapability(CodeActionRequest.type, {
 			documentSelector: Context.haxeSelector,
-			codeActionKinds: [QuickFix, SourceOrganizeImports, SourceSortImports, RefactorExtract]
+			codeActionKinds: [QuickFix, SourceOrganizeImports, SourceSortImports, RefactorExtract],
+			resolveProvider: true,
 		});
 		context.languageServerProtocol.onRequest(CodeActionRequest.type, onCodeAction);
+		context.languageServerProtocol.onRequest(CodeActionResolveRequest.type, onCodeActionResolve);
 
 		registerContributor(new ExtractConstantFeature(context));
 		registerContributor(new DiagnosticsCodeActionFeature(context, diagnostics));
@@ -37,10 +45,36 @@ class CodeActionFeature {
 	}
 
 	function onCodeAction(params:CodeActionParams, token:CancellationToken, resolve:Array<CodeAction>->Void, reject:ResponseError<NoData>->Void) {
+		resolveCallbacks.resize(0);
 		var codeActions = [];
 		for (contributor in contributors) {
 			codeActions = codeActions.concat(contributor.createCodeActions(params));
 		}
 		resolve(codeActions);
+	}
+
+	function onCodeActionResolve(action:CodeAction, token:CancellationToken, resolve:CodeAction->Void, reject:ResponseError<NoData>->Void) {
+		final index = action.data;
+		if (index == null || !(index is Int)) {
+			throw "action.data should be Int index of resolve callback";
+		}
+		final data = resolveCallbacks[index];
+		if (data == null)
+			throw 'resolveCallbacks[$index] is null';
+		switch data {
+			case MissingArg(callback):
+				final promise = callback(action);
+				promise!.then(action -> {
+					resolve(action);
+				});
+		}
+	}
+
+	public static function addResolveData(data:CodeActionResolveData):Int {
+		var i = resolveCallbacks.indexOf(null);
+		if (i == -1)
+			i = resolveCallbacks.length;
+		resolveCallbacks[i] = data;
+		return i;
 	}
 }

--- a/src/haxeLanguageServer/features/haxe/codeAction/CodeActionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/CodeActionFeature.hx
@@ -69,6 +69,13 @@ class CodeActionFeature {
 					final promise = callback(action);
 					promise!.then(action -> {
 						resolve(action);
+						final command = action.command;
+						if (command == null)
+							return;
+						context.languageServerProtocol.sendNotification(LanguageServerMethods.ExecuteClientCommand, {
+							command: command.command,
+							arguments: command.arguments ?? []
+						});
 					});
 			}
 			return;

--- a/src/haxeLanguageServer/features/haxe/codeAction/DiagnosticsCodeActionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/DiagnosticsCodeActionFeature.hx
@@ -231,7 +231,7 @@ class DiagnosticsCodeActionFeature implements CodeActionContributor {
 				data: data,
 				kind: QuickFix,
 				diagnostics: [diagnostic],
-				isPreferred: true,
+				isPreferred: false,
 			});
 		}
 		return actions;

--- a/src/haxeLanguageServer/features/haxe/codeAction/DiagnosticsCodeActionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/DiagnosticsCodeActionFeature.hx
@@ -223,9 +223,12 @@ class DiagnosticsCodeActionFeature implements CodeActionContributor {
 		if (tooManyArgsRe.match(arg)) {
 			final document = context.documents.getHaxe(params.textDocument.uri);
 			final replacement = document.getText(diagnostic.range);
+			final data:CodeActionResolveData = {
+				enumId: CodeActionFeature.addResolveData(MissingArg(action -> createMissingArgumentsAction(action, params, diagnostic)))
+			};
 			actions.push({
 				title: "Add argument",
-				data: CodeActionFeature.addResolveData(MissingArg(action -> createMissingArgumentsAction(action, params, diagnostic))),
+				data: data,
 				kind: QuickFix,
 				diagnostics: [diagnostic],
 				isPreferred: true,
@@ -241,7 +244,6 @@ class DiagnosticsCodeActionFeature implements CodeActionContributor {
 		var fileName:String = document.uri.toFsPath().toString();
 		final pos = document.offsetAt(diagnostic.range.start);
 		var tokenSource = new CancellationTokenSource();
-		final gotoDefinition = new GotoDefinitionFeature(context, false);
 
 		final argToken = document.tokens!.getTokenAtOffset(document.offsetAt(diagnostic.range.start));
 		if (argToken == null)
@@ -250,7 +252,7 @@ class DiagnosticsCodeActionFeature implements CodeActionContributor {
 		if (funPos == null)
 			return null;
 		final gotoPromise = new Promise(function(resolve:(hover:Array<DefinitionLink>) -> Void, reject) {
-			gotoDefinition.onGotoDefinition({
+			context.gotoDefinition.onGotoDefinition({
 				textDocument: params.textDocument,
 				position: funPos.start
 			}, tokenSource.token, array -> {


### PR DESCRIPTION
I would like to call `haxe.codeAction.highlightInsertion` with params to function definition, but you cannot `codeAction/resolve` `edit` and `command` in code action. Maybe someone can add call to this through onNotification/onRequest from server to client?
Example of action:
```haxe
class Main {
	static function main() new Main();
	var fieldFn:()->Void = null;
	public function new() {
		fieldFn(1);

		var local = () -> {}
		local(1);

		function local2(a:Int /**hm**/):Void {}
		local2(1, {x: 1});

		final argName = 1;
		foo(argName);
		foo("some text");
		foo(() -> {});
		foo([2]);

		bar(0, "", 1);

		staticBar(0, 1);

		Main2.foo(1, "foo");
	}
	function foo():Void {}

	function bar(n:Int, f = "data"):Void {}

	static function staticBar(n:Int):Void {}
}

class Main2 {
	public static function foo(foo:Int):Void {}
}
```