### PR TITLE
Set haxe executable and use `npm ci`

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -12,5 +12,5 @@ jobs:
       with:
         submodules: true
     - run: |
-        npm install
+        npm ci
         npx lix run formatter -s . --check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,5 +7,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: npm install
+    - run: npm ci
     - run: npx lix run vshaxe-build -t language-server -t language-server-tests

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
 			"source.sortImports": true
 		}
 	},
+	"haxe.executable": "auto",
 	"haxe.importsSortOrder": "all-alphabetical",
 	"haxeTestExplorer.testCommand": [
 		"npx",

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ However, you can also build it as a standalone project like so:
 ```
 git clone https://github.com/vshaxe/haxe-language-server
 cd haxe-language-server
-npm install
+npm ci
 npx lix run vshaxe-build -t language-server
 ```
 


### PR DESCRIPTION
Fixes broken project when you have `haxe.executable` in global settings.
`npm ci` is:
https://docs.npmjs.com/cli/v9/commands/npm-ci#description