### PR TITLE
[diagnostics] handle related informations if sent by compiler

### DIFF
--- a/src/haxeLanguageServer/features/haxe/DiagnosticsFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/DiagnosticsFeature.hx
@@ -14,6 +14,7 @@ import js.node.ChildProcess;
 import jsonrpc.CancellationToken;
 import languageServerProtocol.Types.Diagnostic;
 import languageServerProtocol.Types.DiagnosticSeverity;
+import languageServerProtocol.Types.Location;
 
 using Lambda;
 
@@ -184,7 +185,14 @@ class DiagnosticsFeature {
 					source: DiagnosticsSource,
 					code: kind,
 					severity: hxDiag.severity,
-					message: hxDiag.kind.getMessage(doc, hxDiag.args, range)
+					message: hxDiag.kind.getMessage(doc, hxDiag.args, range),
+					relatedInformation: hxDiag.relatedInformation?.map(rel -> {
+						location: {
+							uri: rel.location.file.toUri(),
+							range: rel.location.range,
+						},
+						message: rel.message
+					})
 				}
 				if (kind == RemovableCode || kind == UnusedImport || diag.message.contains("has no effect") || kind == InactiveBlock) {
 					diag.severity = Hint;
@@ -398,6 +406,16 @@ private typedef HaxeDiagnostic<T> = {
 	final ?range:Range;
 	final severity:DiagnosticSeverity;
 	final args:T;
+	final relatedInformation:Null<Array<HaxeDiagnosticRelatedInformation>>;
+}
+
+private typedef HaxeDiagnosticRelatedInformation = {
+	final location:{
+		final file:FsPath;
+		final range:Range;
+	};
+	final message:String;
+	final depth:Int;
 }
 
 private typedef HaxeDiagnosticResponse<T> = {


### PR DESCRIPTION
Doesn't have any impact with older Haxe versions, but starting from 4.3 (once https://github.com/HaxeFoundation/haxe/pull/11078 merged), will display better diagnostics

Fixes https://github.com/vshaxe/vshaxe/issues/253
Should also at least improve the situation for https://github.com/vshaxe/vshaxe/issues/388

## Before (or after but with Haxe < 4.3)

![2023-04-02-12:25-27-854385063](https://user-images.githubusercontent.com/6101998/229348657-3d158143-fcfb-4434-a685-489430c023b5.png)

![2023-04-02-12:26-01-998592074](https://user-images.githubusercontent.com/6101998/229348661-46e2ac05-6cd6-40c5-97ed-685cb6bbf35d.png)
_Above is with `Bar.hx` open only, giving diagnostics that make no sense on its own_

![2023-04-02-12:26-43-463873732](https://user-images.githubusercontent.com/6101998/229348664-cc0615c0-7308-4ba9-84fb-b04cfffab14d.png)

## After (Haxe 4.3)

![2023-04-02-13:00-04-020897955](https://user-images.githubusercontent.com/6101998/229348834-9395274d-a058-454c-8ed7-3effe30f256f.png)

![2023-04-02-13:00-19-599204961](https://user-images.githubusercontent.com/6101998/229348837-c4bd5308-70aa-4f21-91d0-50ea7a9469dc.png)
_Above is with `Bar.hx` open only, no diagnostics are relevant there_

![2023-04-02-12:59-05-569102690](https://user-images.githubusercontent.com/6101998/229348841-cb820960-4c8d-49d5-aea3-e5237d54d126.png)
