### PR TITLE
Fix all and parser errors handler

### DIFF
--- a/src/haxeLanguageServer/features/haxe/DiagnosticsFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/DiagnosticsFeature.hx
@@ -24,6 +24,7 @@ class DiagnosticsFeature {
 	public static inline final OrganizeImportsUsingsTitle = "Organize imports/usings";
 	public static inline final RemoveUnusedImportUsingTitle = "Remove unused import/using";
 	public static inline final RemoveAllUnusedImportsUsingsTitle = "Remove all unused imports/usings";
+	public static inline final FixAllTitle = "Fix All";
 
 	final context:Context;
 	final diagnosticsArguments:Map<DocumentUri, DiagnosticsMap<Any>>;

--- a/src/haxeLanguageServer/features/haxe/codeAction/CodeActionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/CodeActionFeature.hx
@@ -23,6 +23,7 @@ typedef CodeActionResolveData = {
 
 class CodeActionFeature {
 	public static inline final SourceSortImports = "source.sortImports";
+	public static inline final SourceFixAll = "source.fixAll";
 
 	final context:Context;
 	final contributors:Array<CodeActionContributor> = [];
@@ -37,7 +38,8 @@ class CodeActionFeature {
 				SourceOrganizeImports,
 				SourceSortImports,
 				RefactorExtract,
-				RefactorRewrite
+				RefactorRewrite,
+				SourceFixAll
 			],
 			resolveProvider: true
 		});

--- a/src/haxeLanguageServer/features/haxe/codeAction/DiagnosticsCodeActionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/DiagnosticsCodeActionFeature.hx
@@ -3,6 +3,7 @@ package haxeLanguageServer.features.haxe.codeAction;
 import haxeLanguageServer.features.haxe.DiagnosticsFeature;
 import haxeLanguageServer.features.haxe.codeAction.CodeActionFeature;
 import haxeLanguageServer.features.haxe.codeAction.diagnostics.CompilerErrorActions;
+import haxeLanguageServer.features.haxe.codeAction.diagnostics.FixAllAction;
 import haxeLanguageServer.features.haxe.codeAction.diagnostics.MissingFieldsActions;
 import haxeLanguageServer.features.haxe.codeAction.diagnostics.OrganizeImportActions;
 import haxeLanguageServer.features.haxe.codeAction.diagnostics.ParserErrorActions;
@@ -47,6 +48,7 @@ class DiagnosticsCodeActionFeature implements CodeActionContributor {
 			});
 		}
 		actions = OrganizeImportActions.createOrganizeImportActions(context, params, actions).concat(actions);
+		actions = FixAllAction.createFixAllAction(context, params, actions).concat(actions);
 		actions = actions.filterDuplicates((a, b) -> a.title == b.title);
 		return actions;
 	}

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/CompilerErrorActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/CompilerErrorActions.hx
@@ -1,5 +1,7 @@
 package haxeLanguageServer.features.haxe.codeAction.diagnostics;
 
+import languageServerProtocol.Types.CodeActionKind;
+
 class CompilerErrorActions {
 	public static function createCompilerErrorActions(context:Context, params:CodeActionParams, diagnostic:Diagnostic):Array<CodeAction> {
 		if ((params.context.only != null) && (!params.context.only.contains(QuickFix))) {
@@ -40,7 +42,7 @@ class CompilerErrorActions {
 				final replacement = document.getText(diagnostic.range).replace(is, shouldBe);
 				actions.push({
 					title: "Change to " + replacement,
-					kind: QuickFix,
+					kind: CodeActionKind.QuickFix + ".auto",
 					edit: WorkspaceEditHelper.create(context, params, [{range: diagnostic.range, newText: replacement}]),
 					diagnostics: [diagnostic],
 					isPreferred: true
@@ -61,7 +63,7 @@ class CompilerErrorActions {
 			}
 			actions.push({
 				title: "Add override keyword",
-				kind: QuickFix,
+				kind: CodeActionKind.QuickFix + ".auto",
 				edit: WorkspaceEditHelper.create(context, params, [{range: pos.toRange(), newText: "override "}]),
 				diagnostics: [diagnostic],
 				isPreferred: true

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/FixAllAction.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/FixAllAction.hx
@@ -1,0 +1,29 @@
+package haxeLanguageServer.features.haxe.codeAction.diagnostics;
+
+import haxeLanguageServer.features.haxe.DiagnosticsFeature.DiagnosticKind;
+import haxeLanguageServer.features.haxe.codeAction.CodeActionFeature;
+import haxeLanguageServer.features.haxe.codeAction.OrganizeImportsFeature;
+import haxeLanguageServer.helper.DocHelper;
+import languageServerProtocol.Types.CodeAction;
+
+class FixAllAction {
+	public static function createFixAllAction(context:Context, params:CodeActionParams, existingActions:Array<CodeAction>):Array<CodeAction> {
+		final uri = params.textDocument.uri;
+		final doc = context.documents.getHaxe(uri);
+		if (doc == null) {
+			return [];
+		}
+
+		final action:CodeAction = {
+			title: DiagnosticsFeature.FixAllTitle,
+			kind: SourceFixAll,
+			command: {
+				title: DiagnosticsFeature.FixAllTitle,
+				command: "haxe.fixAll"
+			},
+			isPreferred: true
+		}
+
+		return [action];
+	}
+}

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ParserErrorActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ParserErrorActions.hx
@@ -58,6 +58,14 @@ class ParserErrorActions {
 							diagnostics: [diagnostic],
 							isPreferred: true
 						});
+					case [Comma, Comma]:
+						actions.push({
+							title: "Remove reduntant ,",
+							kind: CodeActionKind.QuickFix + ".auto",
+							edit: WorkspaceEditHelper.create(context, params, [{range: diagnostic.range, newText: ""}]),
+							diagnostics: [diagnostic],
+							isPreferred: true
+						});
 					case _:
 				}
 			}

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ParserErrorActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ParserErrorActions.hx
@@ -1,5 +1,6 @@
 package haxeLanguageServer.features.haxe.codeAction.diagnostics;
 
+import languageServerProtocol.Types.CodeActionKind;
 import tokentree.TokenTree;
 
 class ParserErrorActions {
@@ -17,7 +18,7 @@ class ParserErrorActions {
 			final document = context.documents.getHaxe(params.textDocument.uri);
 			actions.push({
 				title: "Change to final",
-				kind: QuickFix,
+				kind: CodeActionKind.QuickFix + ".auto",
 				edit: WorkspaceEditHelper.create(context, params, [{range: diagnostic.range, newText: "final"}]),
 				diagnostics: [diagnostic],
 				isPreferred: true
@@ -33,7 +34,7 @@ class ParserErrorActions {
 				if (!hasSemicolon) { // do not generate `;;`
 					actions.push({
 						title: "Add missing ;",
-						kind: QuickFix,
+						kind: CodeActionKind.QuickFix + ".auto",
 						edit: WorkspaceEditHelper.create(context, params, [{range: errRange, newText: ";"}]),
 						diagnostics: [diagnostic],
 						isPreferred: true
@@ -52,7 +53,7 @@ class ParserErrorActions {
 					case [Semicolon, Semicolon]:
 						actions.push({
 							title: "Remove reduntant ;",
-							kind: QuickFix,
+							kind: CodeActionKind.QuickFix + ".auto",
 							edit: WorkspaceEditHelper.create(context, params, [{range: diagnostic.range, newText: ""}]),
 							diagnostics: [diagnostic],
 							isPreferred: true
@@ -71,7 +72,7 @@ class ParserErrorActions {
 				if (!hasComma) { // do not generate `,,`
 					actions.push({
 						title: "Add missing ,",
-						kind: QuickFix,
+						kind: CodeActionKind.QuickFix + ".auto",
 						edit: WorkspaceEditHelper.create(context, params, [{range: errRange, newText: ","}]),
 						diagnostics: [diagnostic],
 						isPreferred: true

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ParserErrorActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ParserErrorActions.hx
@@ -14,6 +14,36 @@ class ParserErrorActions {
 			return actions;
 		}
 
+		if (arg.contains("modifier is not supported for module-level fields")) {
+			final document = context.documents.getHaxe(params.textDocument.uri);
+			final nextText = document.content.substr(document.offsetAt(diagnostic.range.end));
+			final isAuto = nextText.split("{").length == nextText.split("}").length;
+			final token = document!.tokens!.getTokenAtOffset(document.offsetAt(diagnostic.range.end));
+			var range = diagnostic.range;
+			if (token != null) {
+				for (sib in [token.previousSibling, token.nextSibling]) {
+					if (sib == null)
+						continue;
+					if (sib.tok.match(Kwd(KwdStatic)) || sib.tok.match(Kwd(KwdPublic))) {
+						range = range.union(document.rangeAt(sib.pos.min, sib.pos.max));
+					}
+				}
+			}
+			range.end = range.end.translate(0, 1);
+			actions.push({
+				title: "Remove reduntant modifiers",
+				kind: CodeActionKind.QuickFix + (isAuto ? ".auto" : ""),
+				edit: WorkspaceEditHelper.create(context, params, [
+					{
+						range: range,
+						newText: ""
+					}
+				]),
+				diagnostics: [diagnostic],
+				isPreferred: true
+			});
+		}
+
 		if (arg.contains("`final var` is not supported, use `final` instead")) {
 			final document = context.documents.getHaxe(params.textDocument.uri);
 			actions.push({


### PR DESCRIPTION
Can be tested with `settings.json`:
```
"editor.codeActionsOnSave": {
	"source.sortImports": true,
	"source.fixAll": true
},
```
Fixes missing semicolons, commas, overrides and changes `final var` to `final` for now.
Depends on https://github.com/vshaxe/vshaxe/pull/576

I think we need to name all code actions like this: https://dartcode.org/docs/refactorings-and-code-fixes/
And then add enum for `fixAll` command in settings to make customizable list of autofixes (instead of current `quickfix.auto` kind)?

Also i need some explanation what two first early returns in `ParserErrorActions` are doing, this is copypasted from other file.