### PR TITLE
Fix utf8 offsets in actions

### DIFF
--- a/src/haxeLanguageServer/documents/DocumentOffsetKind.hx
+++ b/src/haxeLanguageServer/documents/DocumentOffsetKind.hx
@@ -1,0 +1,6 @@
+package haxeLanguageServer.documents;
+
+enum abstract DocumentOffsetKind(Int) {
+	var Utf8;
+	var Utf16;
+}

--- a/src/haxeLanguageServer/documents/HxTextDocument.hx
+++ b/src/haxeLanguageServer/documents/HxTextDocument.hx
@@ -64,8 +64,8 @@ class HxTextDocument {
 		}
 	}
 
-	public function positionAt(offset:Int, isUtf8 = false):Position {
-		if (isUtf8) {
+	public function positionAt(offset:Int, offsetKind:DocumentOffsetKind = Utf16):Position {
+		if (offsetKind == Utf8) {
 			offset = utf8Offset(content, offset, 1);
 		}
 		offset = Std.int(Math.max(Math.min(offset, content.length), 0));
@@ -85,15 +85,15 @@ class HxTextDocument {
 		return {line: line, character: offset - lineOffsets[line]};
 	}
 
-	overload public extern inline function rangeAt(startOffset:Int, endOffset:Int, isUtf8 = false):Range {
+	overload public extern inline function rangeAt(startOffset:Int, endOffset:Int, offsetKind:DocumentOffsetKind = Utf16):Range {
 		return {
-			start: positionAt(startOffset, isUtf8),
-			end: positionAt(endOffset, isUtf8)
+			start: positionAt(startOffset, offsetKind),
+			end: positionAt(endOffset, offsetKind)
 		};
 	}
 
-	overload public extern inline function rangeAt(pos:haxe.macro.Expr.Position, isUtf8 = false):Range {
-		return rangeAt(pos.min, pos.max, isUtf8);
+	overload public extern inline function rangeAt(pos:haxe.macro.Expr.Position, offsetKind:DocumentOffsetKind = Utf16):Range {
+		return rangeAt(pos.min, pos.max, offsetKind);
 	}
 
 	/**

--- a/src/haxeLanguageServer/features/haxe/codeAction/ExtractFunctionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/ExtractFunctionFeature.hx
@@ -92,7 +92,7 @@ class ExtractFunctionFeature implements CodeActionContributor {
 			newParams = newParams.concat(localVarsToParameter(varTokens, text, rangeIdents));
 
 			final action:Null<CodeAction> = makeExtractFunctionChanges(doc, doc.uri, params, text, isStatic, newParams, returnSpec, indent,
-				doc.positionAt(lastToken.pos.max + 1));
+				doc.positionAt(lastToken.pos.max + 1, true));
 			if (action == null)
 				return [];
 			[action];
@@ -167,7 +167,7 @@ class ExtractFunctionFeature implements CodeActionContributor {
 	}
 
 	function detectIndent(doc:HaxeDocument, functionToken:TokenTree):String {
-		final functionRange:Range = doc.rangeAt(functionToken.pos);
+		final functionRange:Range = doc.rangeAt(functionToken.pos, true);
 		functionRange.start.character = 0;
 
 		final text:String = doc.getText(functionRange);

--- a/src/haxeLanguageServer/features/haxe/codeAction/ExtractFunctionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/ExtractFunctionFeature.hx
@@ -92,7 +92,7 @@ class ExtractFunctionFeature implements CodeActionContributor {
 			newParams = newParams.concat(localVarsToParameter(varTokens, text, rangeIdents));
 
 			final action:Null<CodeAction> = makeExtractFunctionChanges(doc, doc.uri, params, text, isStatic, newParams, returnSpec, indent,
-				doc.positionAt(lastToken.pos.max + 1, true));
+				doc.positionAt(lastToken.pos.max + 1, Utf8));
 			if (action == null)
 				return [];
 			[action];
@@ -167,7 +167,7 @@ class ExtractFunctionFeature implements CodeActionContributor {
 	}
 
 	function detectIndent(doc:HaxeDocument, functionToken:TokenTree):String {
-		final functionRange:Range = doc.rangeAt(functionToken.pos, true);
+		final functionRange:Range = doc.rangeAt(functionToken.pos, Utf8);
 		functionRange.start.character = 0;
 
 		final text:String = doc.getText(functionRange);

--- a/src/haxeLanguageServer/features/haxe/codeAction/ExtractTypeFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/ExtractTypeFeature.hx
@@ -79,7 +79,7 @@ class ExtractTypeFeature implements CodeActionContributor {
 					// expand pos.min to capture doc comment
 					pos.min = tokens.getPos(docComment).min;
 				}
-				final typeRange = doc.rangeAt(pos);
+				final typeRange = doc.rangeAt(pos, true);
 				if (params.range.intersection(typeRange) == null) {
 					// no overlap between selection / cursor pos and Haxe type
 					continue;
@@ -122,7 +122,7 @@ class ExtractTypeFeature implements CodeActionContributor {
 		final pos = tokens.getTreePos(lastImport);
 		pos.min = 0;
 
-		final range = doc.rangeAt(pos);
+		final range = doc.rangeAt(pos, true);
 		range.end.line++;
 		range.end.character = 0;
 		final fileHeader:String = doc.getText(range);
@@ -140,7 +140,7 @@ class ExtractTypeFeature implements CodeActionContributor {
 		if (pack == null)
 			return fileHeader + "\n";
 
-		var packText:String = doc.getText(doc.rangeAt(tokens.getTreePos(pack)));
+		var packText:String = doc.getText(doc.rangeAt(tokens.getTreePos(pack), true));
 		packText = packText.replace("package ", "");
 		packText = packText.replace(";", "").trim();
 		if (packText.length <= 0)

--- a/src/haxeLanguageServer/features/haxe/codeAction/ExtractTypeFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/ExtractTypeFeature.hx
@@ -79,7 +79,7 @@ class ExtractTypeFeature implements CodeActionContributor {
 					// expand pos.min to capture doc comment
 					pos.min = tokens.getPos(docComment).min;
 				}
-				final typeRange = doc.rangeAt(pos, true);
+				final typeRange = doc.rangeAt(pos, Utf8);
 				if (params.range.intersection(typeRange) == null) {
 					// no overlap between selection / cursor pos and Haxe type
 					continue;
@@ -122,7 +122,7 @@ class ExtractTypeFeature implements CodeActionContributor {
 		final pos = tokens.getTreePos(lastImport);
 		pos.min = 0;
 
-		final range = doc.rangeAt(pos, true);
+		final range = doc.rangeAt(pos, Utf8);
 		range.end.line++;
 		range.end.character = 0;
 		final fileHeader:String = doc.getText(range);
@@ -140,7 +140,7 @@ class ExtractTypeFeature implements CodeActionContributor {
 		if (pack == null)
 			return fileHeader + "\n";
 
-		var packText:String = doc.getText(doc.rangeAt(tokens.getTreePos(pack), true));
+		var packText:String = doc.getText(doc.rangeAt(tokens.getTreePos(pack), Utf8));
 		packText = packText.replace("package ", "");
 		packText = packText.replace(";", "").trim();
 		if (packText.length <= 0)

--- a/src/haxeLanguageServer/features/haxe/codeAction/ExtractVarFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/ExtractVarFeature.hx
@@ -191,7 +191,7 @@ class ExtractVarFeature implements CodeActionContributor {
 		for (token in tokens) {
 			if (token == null)
 				continue;
-			final range = doc.rangeAt(token.pos.min, token.pos.max, true);
+			final range = doc.rangeAt(token.pos.min, token.pos.max, Utf8);
 			if (fullRange == null) {
 				fullRange = range;
 				continue;

--- a/src/haxeLanguageServer/features/haxe/codeAction/ExtractVarFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/ExtractVarFeature.hx
@@ -191,7 +191,7 @@ class ExtractVarFeature implements CodeActionContributor {
 		for (token in tokens) {
 			if (token == null)
 				continue;
-			final range = doc.rangeAt(token.pos.min, token.pos.max);
+			final range = doc.rangeAt(token.pos.min, token.pos.max, true);
 			if (fullRange == null) {
 				fullRange = range;
 				continue;
@@ -206,7 +206,7 @@ class ExtractVarFeature implements CodeActionContributor {
 		switch parent.tok {
 			case Kwd(KwdNew):
 				return parent;
-			case Dot:
+			case Dot, QuestionDot:
 				final prevToken = parent.parent ?? return token;
 				if (!token.isCIdent())
 					return token;
@@ -229,7 +229,7 @@ class ExtractVarFeature implements CodeActionContributor {
 		var parent:Null<TokenTree> = token.parent;
 		while (parent != null) {
 			switch parent.tok {
-				case Dot:
+				case Dot, QuestionDot:
 					// skip to start of foo.bar.baz
 					if (parent.parent!.isCIdent() == true) {
 						parent = parent.parent ?? return [];
@@ -240,8 +240,9 @@ class ExtractVarFeature implements CodeActionContributor {
 							return [];
 						case _:
 							// end of a.b expr is inside of Dot
-							final hasDot = token.getFirstChild()!.tok == Dot;
-							final last = hasDot ? token.getFirstChild() : token;
+							final first = token.getFirstChild();
+							final hasDot = first!.tok == Dot || first!.tok == QuestionDot;
+							final last = hasDot ? first : token;
 							return [token, getLastNonCommaToken(last)];
 					}
 				case POpen, BkOpen:
@@ -257,7 +258,7 @@ class ExtractVarFeature implements CodeActionContributor {
 						return [];
 					if (firstChild == null)
 						return tokens;
-					final hasDot = firstChild.tok == Dot;
+					final hasDot = firstChild.tok == Dot || firstChild.tok == QuestionDot;
 					final isCall = firstChild.tok == POpen;
 					final isNew = token.tok.match(Kwd(KwdNew));
 					var lastParent = (hasDot || isCall || isNew) ? firstChild : token;

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ChangeFinalToVarAction.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ChangeFinalToVarAction.hx
@@ -22,7 +22,7 @@ class ChangeFinalToVarAction {
 		final gotoPromise = new Promise(function(resolve:(hover:Array<DefinitionLink>) -> Void, reject) {
 			context.gotoDefinition.onGotoDefinition({
 				textDocument: params.textDocument,
-				position: document.positionAt(varToken.pos.min)
+				position: document.positionAt(varToken.pos.min, true)
 			}, tokenSource.token, array -> {
 				resolve(array);
 			}, error -> reject(error));
@@ -36,7 +36,7 @@ class ChangeFinalToVarAction {
 				return action;
 			final varDefinitionToken = definitionDoc.tokens!.getTokenAtOffset(definitionDoc.offsetAt(definition.targetSelectionRange.start));
 			final kwdFinal = getFinalKwd(varDefinitionToken) ?? return action;
-			final range = document.rangeAt(kwdFinal.pos.min, kwdFinal.pos.max);
+			final range = document.rangeAt(kwdFinal.pos.min, kwdFinal.pos.max, true);
 			action.edit = WorkspaceEditHelper.create(definitionDoc, [{range: range, newText: "var"}]);
 			return action;
 		});

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ChangeFinalToVarAction.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ChangeFinalToVarAction.hx
@@ -22,7 +22,7 @@ class ChangeFinalToVarAction {
 		final gotoPromise = new Promise(function(resolve:(hover:Array<DefinitionLink>) -> Void, reject) {
 			context.gotoDefinition.onGotoDefinition({
 				textDocument: params.textDocument,
-				position: document.positionAt(varToken.pos.min, true)
+				position: document.positionAt(varToken.pos.min, Utf8)
 			}, tokenSource.token, array -> {
 				resolve(array);
 			}, error -> reject(error));
@@ -36,7 +36,7 @@ class ChangeFinalToVarAction {
 				return action;
 			final varDefinitionToken = definitionDoc.tokens!.getTokenAtOffset(definitionDoc.offsetAt(definition.targetSelectionRange.start));
 			final kwdFinal = getFinalKwd(varDefinitionToken) ?? return action;
-			final range = document.rangeAt(kwdFinal.pos.min, kwdFinal.pos.max, true);
+			final range = document.rangeAt(kwdFinal.pos.min, kwdFinal.pos.max, Utf8);
 			action.edit = WorkspaceEditHelper.create(definitionDoc, [{range: range, newText: "var"}]);
 			return action;
 		});

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/MissingArgumentsAction.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/MissingArgumentsAction.hx
@@ -168,7 +168,7 @@ class MissingArgumentsAction {
 			return null;
 		}
 		final tokenPos = parent.token.pos;
-		return document.rangeAt(tokenPos.min, tokenPos.max);
+		return document.rangeAt(tokenPos.min, tokenPos.max, true);
 	}
 
 	static function getFunctionPOpen(funIdent:Null<TokenTree>):Null<TokenTree> {
@@ -195,7 +195,7 @@ class MissingArgumentsAction {
 		if (pClose == null) {
 			return null;
 		}
-		return document.rangeAt(pClose.pos.min, pClose.pos.min);
+		return document.rangeAt(pClose.pos.min, pClose.pos.min, true);
 	}
 
 	static function functionArgsCount(document:HaxeDocument, funIdent:Null<TokenTree>):Int {

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/MissingArgumentsAction.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/MissingArgumentsAction.hx
@@ -168,7 +168,7 @@ class MissingArgumentsAction {
 			return null;
 		}
 		final tokenPos = parent.token.pos;
-		return document.rangeAt(tokenPos.min, tokenPos.max, true);
+		return document.rangeAt(tokenPos.min, tokenPos.max, Utf8);
 	}
 
 	static function getFunctionPOpen(funIdent:Null<TokenTree>):Null<TokenTree> {
@@ -195,7 +195,7 @@ class MissingArgumentsAction {
 		if (pClose == null) {
 			return null;
 		}
-		return document.rangeAt(pClose.pos.min, pClose.pos.min, true);
+		return document.rangeAt(pClose.pos.min, pClose.pos.min, Utf8);
 	}
 
 	static function functionArgsCount(document:HaxeDocument, funIdent:Null<TokenTree>):Int {

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/MissingFieldsActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/MissingFieldsActions.hx
@@ -62,12 +62,12 @@ class MissingFieldsActions {
 				if (classToken == null) {
 					moduleLevelField = true;
 					final lastPos = document.content.length - 1;
-					rangeFieldInsertion = document.rangeAt(lastPos, lastPos);
+					rangeFieldInsertion = document.rangeAt(lastPos, lastPos, true);
 				} else {
 					var pos = tokens.getPos(classToken);
-					rangeClass = document.rangeAt(pos.min, pos.min);
+					rangeClass = document.rangeAt(pos.min, pos.min, true);
 					var pos = tokens.getTreePos(classToken);
-					rangeFieldInsertion = document.rangeAt(pos.max - 1, pos.max - 1);
+					rangeFieldInsertion = document.rangeAt(pos.max - 1, pos.max - 1, true);
 				}
 			case _:
 				return [];
@@ -250,17 +250,17 @@ class MissingFieldsActions {
 		}
 		// add statics to the top
 		if (fieldScope == Static) {
-			return document.rangeAt(brOpen.pos.max, brOpen.pos.max);
+			return document.rangeAt(brOpen.pos.max, brOpen.pos.max, true);
 		}
 		// find place for field before first function in class
 		final firstFun = brOpen.access().firstOf(Kwd(KwdFunction));
 		final prev = firstFun!.token!.previousSibling;
 		// if function is first add var at the top
 		if (prev == null) {
-			return document.rangeAt(brOpen.pos.max, brOpen.pos.max);
+			return document.rangeAt(brOpen.pos.max, brOpen.pos.max, true);
 		}
 		final pos = prev.getPos();
-		return document.rangeAt(pos.max, pos.max);
+		return document.rangeAt(pos.max, pos.max, true);
 	}
 
 	static function getNewClassFunctionPos(document:HaxeDocument, classToken:TokenTree, callToken:TokenTree):Null<Range> {
@@ -278,7 +278,7 @@ class MissingFieldsActions {
 			if (callPos.min < tokenPos.min || callPos.min > tokenPos.max)
 				continue;
 			if (token.tok.match(Kwd(KwdFunction))) {
-				return document.rangeAt(tokenPos.max + 1, tokenPos.max + 1);
+				return document.rangeAt(tokenPos.max + 1, tokenPos.max + 1, true);
 			}
 		}
 		return null;

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/MissingFieldsActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/MissingFieldsActions.hx
@@ -62,12 +62,12 @@ class MissingFieldsActions {
 				if (classToken == null) {
 					moduleLevelField = true;
 					final lastPos = document.content.length - 1;
-					rangeFieldInsertion = document.rangeAt(lastPos, lastPos, true);
+					rangeFieldInsertion = document.rangeAt(lastPos, lastPos, Utf8);
 				} else {
 					var pos = tokens.getPos(classToken);
-					rangeClass = document.rangeAt(pos.min, pos.min, true);
+					rangeClass = document.rangeAt(pos.min, pos.min, Utf8);
 					var pos = tokens.getTreePos(classToken);
-					rangeFieldInsertion = document.rangeAt(pos.max - 1, pos.max - 1, true);
+					rangeFieldInsertion = document.rangeAt(pos.max - 1, pos.max - 1, Utf8);
 				}
 			case _:
 				return [];
@@ -250,17 +250,17 @@ class MissingFieldsActions {
 		}
 		// add statics to the top
 		if (fieldScope == Static) {
-			return document.rangeAt(brOpen.pos.max, brOpen.pos.max, true);
+			return document.rangeAt(brOpen.pos.max, brOpen.pos.max, Utf8);
 		}
 		// find place for field before first function in class
 		final firstFun = brOpen.access().firstOf(Kwd(KwdFunction));
 		final prev = firstFun!.token!.previousSibling;
 		// if function is first add var at the top
 		if (prev == null) {
-			return document.rangeAt(brOpen.pos.max, brOpen.pos.max, true);
+			return document.rangeAt(brOpen.pos.max, brOpen.pos.max, Utf8);
 		}
 		final pos = prev.getPos();
-		return document.rangeAt(pos.max, pos.max, true);
+		return document.rangeAt(pos.max, pos.max, Utf8);
 	}
 
 	static function getNewClassFunctionPos(document:HaxeDocument, classToken:TokenTree, callToken:TokenTree):Null<Range> {
@@ -278,7 +278,7 @@ class MissingFieldsActions {
 			if (callPos.min < tokenPos.min || callPos.min > tokenPos.max)
 				continue;
 			if (token.tok.match(Kwd(KwdFunction))) {
-				return document.rangeAt(tokenPos.max + 1, tokenPos.max + 1, true);
+				return document.rangeAt(tokenPos.max + 1, tokenPos.max + 1, Utf8);
 			}
 		}
 		return null;

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ParserErrorActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ParserErrorActions.hx
@@ -25,7 +25,7 @@ class ParserErrorActions {
 					if (sib == null)
 						continue;
 					if (sib.tok.match(Kwd(KwdStatic)) || sib.tok.match(Kwd(KwdPublic))) {
-						range = range.union(document.rangeAt(sib.pos.min, sib.pos.max));
+						range = range.union(document.rangeAt(sib.pos.min, sib.pos.max, true));
 					}
 				}
 			}
@@ -135,7 +135,7 @@ class ParserErrorActions {
 			return null;
 		final last = getLastNonCommentToken(prev);
 		final pos = last.getPos();
-		return document.rangeAt(pos.max, pos.max);
+		return document.rangeAt(pos.max, pos.max, true);
 	}
 
 	static function getPrevNonCommentSibling(token:Null<TokenTree>):Null<TokenTree> {

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ParserErrorActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ParserErrorActions.hx
@@ -25,7 +25,7 @@ class ParserErrorActions {
 					if (sib == null)
 						continue;
 					if (sib.tok.match(Kwd(KwdStatic)) || sib.tok.match(Kwd(KwdPublic))) {
-						range = range.union(document.rangeAt(sib.pos.min, sib.pos.max, true));
+						range = range.union(document.rangeAt(sib.pos.min, sib.pos.max, Utf8));
 					}
 				}
 			}
@@ -135,7 +135,7 @@ class ParserErrorActions {
 			return null;
 		final last = getLastNonCommentToken(prev);
 		final pos = last.getPos();
-		return document.rangeAt(pos.max, pos.max, true);
+		return document.rangeAt(pos.max, pos.max, Utf8);
 	}
 
 	static function getPrevNonCommentSibling(token:Null<TokenTree>):Null<TokenTree> {

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/UpdateSyntaxActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/UpdateSyntaxActions.hx
@@ -50,7 +50,7 @@ class UpdateSyntaxActions {
 		final prev = ifToken.previousSibling ?? return;
 		final varIdent = getIdentAssignToken(doc, prev) ?? return;
 		final varIdentEnd = getIdentEnd(varIdent);
-		final varIdentRange = doc.rangeAt(varIdent.pos, true).union(doc.rangeAt(varIdentEnd.pos, true));
+		final varIdentRange = doc.rangeAt(varIdent.pos, Utf8).union(doc.rangeAt(varIdentEnd.pos, Utf8));
 		final varNameName = doc.getText(varIdentRange);
 		if (varNameName != ifVarName)
 			return;
@@ -65,9 +65,9 @@ class UpdateSyntaxActions {
 		if (!value.endsWith(";"))
 			value += ";";
 		final prevValueToken = varIdent.getFirstChild()!.getFirstChild() ?? return;
-		final prevValueRange = doc.rangeAt(prevValueToken.getPos(), true);
+		final prevValueRange = doc.rangeAt(prevValueToken.getPos(), Utf8);
 		final prevValue = doc.getText(prevValueRange);
-		final replaceRange = prevValueRange.union(doc.rangeAt(ifToken.getPos(), true));
+		final replaceRange = prevValueRange.union(doc.rangeAt(ifToken.getPos(), Utf8));
 		actions.push({
 			title: "Change to ?? operator",
 			kind: QuickFix,
@@ -90,7 +90,7 @@ class UpdateSyntaxActions {
 		var value = doc.getText(ranges.value);
 		if (!value.endsWith(";"))
 			value += ";";
-		final replaceRange = doc.rangeAt(ifToken.getPos(), true);
+		final replaceRange = doc.rangeAt(ifToken.getPos(), Utf8);
 		actions.push({
 			title: "Change to ??= operator",
 			kind: QuickFix,
@@ -107,7 +107,7 @@ class UpdateSyntaxActions {
 	static function addSaveNavIfNotNullAction(context:Context, params:CodeActionParams, actions:Array<CodeAction>, doc:HaxeDocument, ifToken:TokenTree,
 			ifVarName:String) {
 		final ident = getSingleLineIfBodyExpr(ifToken) ?? return;
-		final varName = doc.getText(doc.rangeAt(ident.getPos(), true));
+		final varName = doc.getText(doc.rangeAt(ident.getPos(), Utf8));
 		if (!varName.startsWith(ifVarName))
 			return;
 		var accessPart = varName.replace(ifVarName, "");
@@ -119,7 +119,7 @@ class UpdateSyntaxActions {
 		}
 		if (!accessPart.endsWith(";"))
 			accessPart += ";";
-		final replaceRange = doc.rangeAt(ifToken.getPos(), true);
+		final replaceRange = doc.rangeAt(ifToken.getPos(), Utf8);
 		actions.push({
 			title: "Change to ?. operator",
 			kind: QuickFix,
@@ -151,7 +151,7 @@ class UpdateSyntaxActions {
 		var ident = getSingleLineIfBodyExpr(ifToken) ?? cast return null;
 		switch ident.tok {
 			case Kwd(KwdReturn | KwdBreak | KwdContinue | KwdThrow):
-				return doc.rangeAt(ident.getPos(), true);
+				return doc.rangeAt(ident.getPos(), Utf8);
 			case _:
 				return null;
 		}
@@ -177,7 +177,7 @@ class UpdateSyntaxActions {
 		final kwdNull = opEq.getFirstChild() ?? cast return null;
 		switch [opEq.tok, kwdNull.tok] {
 			case [Binop(OpEq), Kwd(KwdNull)]:
-				return doc.rangeAt(ident.pos, true).union(doc.rangeAt(identEnd.pos, true));
+				return doc.rangeAt(ident.pos, Utf8).union(doc.rangeAt(identEnd.pos, Utf8));
 			case _:
 				return null;
 		}
@@ -191,7 +191,7 @@ class UpdateSyntaxActions {
 		final kwdNull = opNotEq.getFirstChild() ?? cast return null;
 		switch [opNotEq.tok, kwdNull.tok] {
 			case [Binop(OpNotEq), Kwd(KwdNull)]:
-				return doc.rangeAt(ident.pos, true).union(doc.rangeAt(identEnd.pos, true));
+				return doc.rangeAt(ident.pos, Utf8).union(doc.rangeAt(identEnd.pos, Utf8));
 			case _:
 				return null;
 		}
@@ -205,8 +205,8 @@ class UpdateSyntaxActions {
 		switch opAssign.tok {
 			case Binop(OpAssign):
 				return {
-					varName: doc.rangeAt(ident2.pos, true).union(doc.rangeAt(ident2End.pos, true)),
-					value: doc.rangeAt(value.getPos(), true)
+					varName: doc.rangeAt(ident2.pos, Utf8).union(doc.rangeAt(ident2End.pos, Utf8)),
+					value: doc.rangeAt(value.getPos(), Utf8)
 				};
 			case _:
 				return null;

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/UpdateSyntaxActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/UpdateSyntaxActions.hx
@@ -50,7 +50,7 @@ class UpdateSyntaxActions {
 		final prev = ifToken.previousSibling ?? return;
 		final varIdent = getIdentAssignToken(doc, prev) ?? return;
 		final varIdentEnd = getIdentEnd(varIdent);
-		final varIdentRange = doc.rangeAt(varIdent.pos).union(doc.rangeAt(varIdentEnd.pos));
+		final varIdentRange = doc.rangeAt(varIdent.pos, true).union(doc.rangeAt(varIdentEnd.pos, true));
 		final varNameName = doc.getText(varIdentRange);
 		if (varNameName != ifVarName)
 			return;
@@ -65,9 +65,9 @@ class UpdateSyntaxActions {
 		if (!value.endsWith(";"))
 			value += ";";
 		final prevValueToken = varIdent.getFirstChild()!.getFirstChild() ?? return;
-		final prevValueRange = doc.rangeAt(prevValueToken.getPos());
+		final prevValueRange = doc.rangeAt(prevValueToken.getPos(), true);
 		final prevValue = doc.getText(prevValueRange);
-		final replaceRange = prevValueRange.union(doc.rangeAt(ifToken.getPos()));
+		final replaceRange = prevValueRange.union(doc.rangeAt(ifToken.getPos(), true));
 		actions.push({
 			title: "Change to ?? operator",
 			kind: QuickFix,
@@ -90,7 +90,7 @@ class UpdateSyntaxActions {
 		var value = doc.getText(ranges.value);
 		if (!value.endsWith(";"))
 			value += ";";
-		final replaceRange = doc.rangeAt(ifToken.getPos());
+		final replaceRange = doc.rangeAt(ifToken.getPos(), true);
 		actions.push({
 			title: "Change to ??= operator",
 			kind: QuickFix,
@@ -107,7 +107,7 @@ class UpdateSyntaxActions {
 	static function addSaveNavIfNotNullAction(context:Context, params:CodeActionParams, actions:Array<CodeAction>, doc:HaxeDocument, ifToken:TokenTree,
 			ifVarName:String) {
 		final ident = getSingleLineIfBodyExpr(ifToken) ?? return;
-		final varName = doc.getText(doc.rangeAt(ident.getPos()));
+		final varName = doc.getText(doc.rangeAt(ident.getPos(), true));
 		if (!varName.startsWith(ifVarName))
 			return;
 		var accessPart = varName.replace(ifVarName, "");
@@ -119,7 +119,7 @@ class UpdateSyntaxActions {
 		}
 		if (!accessPart.endsWith(";"))
 			accessPart += ";";
-		final replaceRange = doc.rangeAt(ifToken.getPos());
+		final replaceRange = doc.rangeAt(ifToken.getPos(), true);
 		actions.push({
 			title: "Change to ?. operator",
 			kind: QuickFix,
@@ -151,7 +151,7 @@ class UpdateSyntaxActions {
 		var ident = getSingleLineIfBodyExpr(ifToken) ?? cast return null;
 		switch ident.tok {
 			case Kwd(KwdReturn | KwdBreak | KwdContinue | KwdThrow):
-				return doc.rangeAt(ident.getPos());
+				return doc.rangeAt(ident.getPos(), true);
 			case _:
 				return null;
 		}
@@ -177,7 +177,7 @@ class UpdateSyntaxActions {
 		final kwdNull = opEq.getFirstChild() ?? cast return null;
 		switch [opEq.tok, kwdNull.tok] {
 			case [Binop(OpEq), Kwd(KwdNull)]:
-				return doc.rangeAt(ident.pos).union(doc.rangeAt(identEnd.pos));
+				return doc.rangeAt(ident.pos, true).union(doc.rangeAt(identEnd.pos, true));
 			case _:
 				return null;
 		}
@@ -191,7 +191,7 @@ class UpdateSyntaxActions {
 		final kwdNull = opNotEq.getFirstChild() ?? cast return null;
 		switch [opNotEq.tok, kwdNull.tok] {
 			case [Binop(OpNotEq), Kwd(KwdNull)]:
-				return doc.rangeAt(ident.pos).union(doc.rangeAt(identEnd.pos));
+				return doc.rangeAt(ident.pos, true).union(doc.rangeAt(identEnd.pos, true));
 			case _:
 				return null;
 		}
@@ -205,8 +205,8 @@ class UpdateSyntaxActions {
 		switch opAssign.tok {
 			case Binop(OpAssign):
 				return {
-					varName: doc.rangeAt(ident2.pos).union(doc.rangeAt(ident2End.pos)),
-					value: doc.rangeAt(value.getPos())
+					varName: doc.rangeAt(ident2.pos, true).union(doc.rangeAt(ident2End.pos, true)),
+					value: doc.rangeAt(value.getPos(), true)
 				};
 			case _:
 				return null;


### PR DESCRIPTION
Maybe not fitting well, but much better than writing call like this instead:
```haxe
final range = document.rangeAt(context.displayOffsetConverter.utf8OffsetToCharacterOffset(document.content, pos.max),
      context.displayOffsetConverter.utf8OffsetToCharacterOffset(document.content, pos.max));
```
There is some other offset places, they can be checked with this regexes in vscode search:
`rangeAt\(.+?(?!true)\)`
`positionAt\(.+?(?!true)\)`
I changed mostly places that i tested.

Closes https://github.com/vshaxe/vshaxe/issues/583