### PR TITLE
Snippets in actions and more

### DIFF
--- a/src/haxeLanguageServer/Configuration.hx
+++ b/src/haxeLanguageServer/Configuration.hx
@@ -103,11 +103,16 @@ typedef UserConfig = {
 	var serverRecording:ServerRecordingConfig;
 }
 
-private typedef InitOptions = {
+typedef ExperimentalCapabilities = {
+	?supportedCommands:Array<String>
+}
+
+typedef InitOptions = {
 	var displayServerConfig:DisplayServerConfig;
 	var displayArguments:Array<String>;
 	var haxelibConfig:HaxelibConfig;
 	var sendMethodResults:Bool;
+	var experimentalClientCapabilities:ExperimentalCapabilities;
 }
 
 enum ConfigurationKind {
@@ -132,7 +137,10 @@ class Configuration {
 		haxelibConfig: {
 			executable: "haxelib"
 		},
-		sendMethodResults: false
+		sendMethodResults: false,
+		experimentalClientCapabilities: {
+			supportedCommands: []
+		}
 	};
 
 	static final DefaultUserSettings:UserConfig = {

--- a/src/haxeLanguageServer/Context.hx
+++ b/src/haxeLanguageServer/Context.hx
@@ -7,6 +7,8 @@ import haxe.display.Protocol.HaxeResponseErrorData;
 import haxe.display.Protocol.Methods as HaxeMethods;
 import haxe.display.Protocol.Response;
 import haxe.display.Server.ServerMethods;
+import haxeLanguageServer.Configuration.ExperimentalCapabilities;
+import haxeLanguageServer.Configuration.InitOptions;
 import haxeLanguageServer.LanguageServerMethods.MethodResult;
 import haxeLanguageServer.features.CompletionFeature;
 import haxeLanguageServer.features.HoverFeature;
@@ -151,6 +153,12 @@ class Context {
 			workspacePath = params.rootUri.toFsPath();
 		}
 		capabilities = params.capabilities;
+		capabilities.experimental ??= {}
+		final initOptions:Null<InitOptions> = params.initializationOptions;
+		final experimentals = initOptions!.experimentalClientCapabilities;
+		if (experimentals != null) {
+			capabilities.experimental.supportedCommands = experimentals.supportedCommands;
+		}
 		config.onInitialize(params);
 		serverRecording.onInitialize(this);
 
@@ -342,6 +350,12 @@ class Context {
 				}
 			]
 		}, null, _ -> {}, error -> trace(error));
+	}
+
+	public function hasClientCommandSupport(command:String):Bool {
+		final experimental:ExperimentalCapabilities = capabilities.experimental ?? return false;
+		final supportedCommands = experimental.supportedCommands ?? return false;
+		return supportedCommands.contains(command);
 	}
 
 	function restartServer(reason:String) {

--- a/src/haxeLanguageServer/features/haxe/codeAction/CodeActionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/CodeActionFeature.hx
@@ -29,6 +29,7 @@ class CodeActionFeature {
 
 	final context:Context;
 	final contributors:Array<CodeActionContributor> = [];
+	final hasCommandResolveSupport:Bool;
 
 	public function new(context) {
 		this.context = context;
@@ -45,6 +46,7 @@ class CodeActionFeature {
 			],
 			resolveProvider: true
 		});
+		hasCommandResolveSupport = context.capabilities.textDocument!.codeAction!.resolveSupport!.properties.contains("command");
 		context.languageServerProtocol.onRequest(CodeActionRequest.type, onCodeAction);
 		context.languageServerProtocol.onRequest(CodeActionResolveRequest.type, onCodeActionResolve);
 
@@ -96,7 +98,7 @@ class CodeActionFeature {
 				promise.then(action -> {
 					resolve(action);
 					final command = action.command;
-					if (command == null)
+					if (command == null || hasCommandResolveSupport)
 						return;
 					context.languageServerProtocol.sendNotification(LanguageServerMethods.ExecuteClientCommand, {
 						command: command.command,

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ChangeFinalToVarAction.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ChangeFinalToVarAction.hx
@@ -8,7 +8,7 @@ import tokentree.TokenTree;
 class ChangeFinalToVarAction {
 	public static function createChangeFinalToVarAction(context:Context, action:CodeAction, params:CodeActionParams,
 			diagnostic:Diagnostic):Null<Promise<CodeAction>> {
-		if ((params.context.only != null) && (!params.context.only.contains(RefactorRewrite))) {
+		if ((params.context.only != null) && (!params.context.only.contains(RefactorExtract))) {
 			return null;
 		}
 		final document = context.documents.getHaxe(params.textDocument.uri);

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ChangeFinalToVarAction.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ChangeFinalToVarAction.hx
@@ -8,7 +8,7 @@ import tokentree.TokenTree;
 class ChangeFinalToVarAction {
 	public static function createChangeFinalToVarAction(context:Context, action:CodeAction, params:CodeActionParams,
 			diagnostic:Diagnostic):Null<Promise<CodeAction>> {
-		if ((params.context.only != null) && (!params.context.only.contains(RefactorExtract))) {
+		if ((params.context.only != null) && (!params.context.only.contains(QuickFix))) {
 			return null;
 		}
 		final document = context.documents.getHaxe(params.textDocument.uri);

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/CompilerErrorActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/CompilerErrorActions.hx
@@ -82,7 +82,7 @@ class CompilerErrorActions {
 			actions.push({
 				title: "Add argument",
 				data: data,
-				kind: RefactorRewrite,
+				kind: QuickFix,
 				diagnostics: [diagnostic],
 				isPreferred: false
 			});
@@ -99,7 +99,7 @@ class CompilerErrorActions {
 			actions.push({
 				title: "Change final to var",
 				data: data,
-				kind: QuickFix,
+				kind: RefactorExtract,
 				diagnostics: [diagnostic],
 				isPreferred: false
 			});

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/CompilerErrorActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/CompilerErrorActions.hx
@@ -99,7 +99,7 @@ class CompilerErrorActions {
 			actions.push({
 				title: "Change final to var",
 				data: data,
-				kind: RefactorExtract,
+				kind: QuickFix,
 				diagnostics: [diagnostic],
 				isPreferred: false
 			});

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/MissingFieldsActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/MissingFieldsActions.hx
@@ -184,7 +184,10 @@ class MissingFieldsActions {
 					var id = 0;
 					final args = signature!.args ?? [];
 					for (arg in args) {
-						var argName = MissingArgumentsAction.genArgNameFromJsonType(arg.t);
+						var argName = arg.name;
+						if (argName.startsWith("arg") && argName.length == 4) {
+							argName = MissingArgumentsAction.genArgNameFromJsonType(arg.t);
+						}
 						for (i in 1...10) {
 							final name = argName + (i == 1 ? "" : '$i');
 							if (!argNames.contains(name)) {

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/MissingFieldsActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/MissingFieldsActions.hx
@@ -78,6 +78,8 @@ class MissingFieldsActions {
 		final fieldFormatting = context.config.user.codeGeneration.functions.field;
 		final printer = new DisplayPrinter(false, if (importConfig.enableAutoImports) Shadowed else Qualified, fieldFormatting);
 		var allEdits = [];
+		final isSnippet = context.hasClientCommandSupport("haxe.codeAction.insertSnippet");
+		var snippetEdit:Null<TextEdit> = null;
 		var allDotPaths = [];
 		for (entry in args.entries) {
 			var fields = entry.fields.copy();
@@ -164,7 +166,8 @@ class MissingFieldsActions {
 				case Some(title): title;
 				case None: return [];
 			}
-			var edits = [];
+			final edits = [];
+			var snippetEditId = -1;
 			final getQualified = printer.collectQualifiedPaths();
 			fields.sort((a, b) -> a.field.pos.min - b.field.pos.min);
 			for (field in fields) {
@@ -175,8 +178,29 @@ class MissingFieldsActions {
 					for (expr in field.field.expr.string.split("\n")) {
 						expressions.push(expr);
 					}
-				} else if (field.type.extractFunctionSignature().check(f -> !f.ret.isVoid())) {
-					expressions.push("throw new haxe.exceptions.NotImplementedException()");
+				} else {
+					final signature = field.type.extractFunctionSignature();
+					final argNames = [];
+					var id = 0;
+					final args = signature!.args ?? [];
+					for (arg in args) {
+						var argName = MissingArgumentsAction.genArgNameFromJsonType(arg.t);
+						for (i in 1...10) {
+							final name = argName + (i == 1 ? "" : '$i');
+							if (!argNames.contains(name)) {
+								argNames.push(argName);
+								argName = name;
+								break;
+							}
+						}
+						id++;
+						final isSnippet = isSnippet && snippetEditId == -1;
+						arg.name = isSnippet ? '$${$id:$argName}' : argName;
+					}
+					snippetEditId = edits.length;
+					if (signature.check(f -> !f.ret.isVoid())) {
+						expressions.push("throw new haxe.exceptions.NotImplementedException()");
+					}
 				}
 				buf.add(printer.printClassFieldImplementation(field.field, field.type, false, moduleLevelField, expressions));
 
@@ -213,14 +237,28 @@ class MissingFieldsActions {
 			final codeAction:CodeAction = {
 				title: title,
 				kind: QuickFix,
-				edit: WorkspaceEditHelper.create(document, edits),
 				diagnostics: [diagnostic]
 			};
-			if (entry.cause.kind == FieldAccess) {
+			snippetEdit = edits[snippetEditId];
+			if (snippetEdit != null) {
+				var text = snippetEdit.newText;
+				final matchBodyExpr = ~/({\n[\t ]+)(.+)\n/;
+				if (matchBodyExpr.match(text)) {
+					text = matchBodyExpr.replace(text, '$1$${0:$2}\n');
+				}
 				codeAction.command = {
-					title: "Highlight Insertion",
-					command: "haxe.codeAction.highlightInsertion",
-					arguments: [document.uri.toString(), rangeFieldInsertion]
+					title: "Insert Snippet",
+					command: "haxe.codeAction.insertSnippet",
+					arguments: [document.uri.toString(), rangeFieldInsertion, text]
+				}
+			} else {
+				codeAction.edit = WorkspaceEditHelper.create(document, edits);
+				if (entry.cause.kind == FieldAccess) {
+					codeAction.command = {
+						title: "Highlight Insertion",
+						command: "haxe.codeAction.highlightInsertion",
+						arguments: [document.uri.toString(), rangeFieldInsertion]
+					}
 				}
 			}
 			actions.unshift(codeAction);
@@ -230,12 +268,23 @@ class MissingFieldsActions {
 			if (allDotPaths.length > 0) {
 				allEdits.push(createImportsEdit(document, determineImportPosition(document), allDotPaths, importConfig.style));
 			}
-			actions.unshift({
+			final action:CodeAction = {
 				title: "Implement all missing fields",
 				kind: QuickFix,
-				edit: WorkspaceEditHelper.create(document, allEdits),
 				diagnostics: [diagnostic]
-			});
+			};
+			if (snippetEdit != null) {
+				final item = allEdits.find(item -> item.newText == snippetEdit.newText);
+				if (item != null)
+					allEdits.remove(item);
+				action.command = {
+					title: "Insert Snippet",
+					command: "haxe.codeAction.insertSnippet",
+					arguments: [document.uri.toString(), snippetEdit.range, snippetEdit.newText]
+				}
+			}
+			action.edit = WorkspaceEditHelper.create(document, allEdits);
+			actions.unshift(action);
 		}
 		if (actions.length > 0) {
 			actions[0].isPreferred = true;

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/UpdateSyntaxActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/UpdateSyntaxActions.hx
@@ -74,11 +74,33 @@ class UpdateSyntaxActions {
 			edit: WorkspaceEditHelper.create(context, params, [
 				{
 					range: replaceRange,
-					newText: '$prevValue ?? $value'
-					// newText: FormatterHelper.formatText(doc, context, '$ifName ??= $value', ExpressionLevel);
+					newText: '$prevValue ?? ${multilineIndent(doc, context, value, replaceRange.start)}'
 				}
 			]),
 		});
+	}
+
+	static function multilineIndent(doc:HaxeDocument, context:Context, value:String, pos:Position):String {
+		if (!value.contains("\n"))
+			return value;
+		value = FormatterHelper.formatText(doc, context, value, ExpressionLevel);
+		final line = doc.lineAt(pos.line);
+		final count = lineIndentationCount(line);
+		if (count == 0)
+			return value;
+		final prefix = "".rpad(line.charAt(0), count);
+		value = value.split("\n").mapi((i, s) -> i == 0 ? s : '$prefix$s').join("\n");
+		return value;
+	}
+
+	static function lineIndentationCount(s:String):Int {
+		var spaces = 0;
+		for (i => _ in s) {
+			if (!s.isSpace(i))
+				break;
+			spaces++;
+		}
+		return spaces;
 	}
 
 	static function addNullCoalAssignAction(context:Context, params:CodeActionParams, actions:Array<CodeAction>, doc:HaxeDocument, ifToken:TokenTree,
@@ -97,8 +119,7 @@ class UpdateSyntaxActions {
 			edit: WorkspaceEditHelper.create(context, params, [
 				{
 					range: replaceRange,
-					newText: '$ifVarName ??= $value'
-					// newText: FormatterHelper.formatText(doc, context, '$ifName ??= $value', ExpressionLevel);
+					newText: '$ifVarName ??= ${multilineIndent(doc, context, value, replaceRange.start)}'
 				}
 			]),
 		});
@@ -127,7 +148,6 @@ class UpdateSyntaxActions {
 				{
 					range: replaceRange,
 					newText: '$ifVarName$accessPart'
-					// newText: FormatterHelper.formatText(doc, context, '$ifName ??= $value', ExpressionLevel);
 				}
 			]),
 		});


### PR DESCRIPTION
- Clients can pass supported commands to enable more experimental features
- If client has `insertSnippet` command, use it in function generation, arg generation and var extraction
- Check for `command` support in codeaction resolve requests, to prevent double command calls. This support is already in VSCode Insiders and can be released in days.
- Better arg names in function generation
- Move arg generation to `QuickFix`: currently if you want to fix arg error and open action menu, this fix is after `extract var`, because of `RefactorRewrite` category. I really want to keep this as quickfix, to keep all code fixes at the top of actions list for better ux
- Indentation fixes for multiline values in var extraction and nullCoal generators