### PR TITLE
[diagnostics] indent related information to show sub error depth

### DIFF
--- a/src/haxeLanguageServer/features/haxe/DiagnosticsFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/DiagnosticsFeature.hx
@@ -188,7 +188,7 @@ class DiagnosticsFeature {
 							uri: rel.location.file.toUri(),
 							range: rel.location.range,
 						},
-						message: rel.message
+						message: convertIndentation(rel.message, rel.depth)
 					})
 				}
 				if (kind == RemovableCode || kind == UnusedImport || diag.message.contains("has no effect") || kind == InactiveBlock) {
@@ -252,6 +252,23 @@ class DiagnosticsFeature {
 			|| !diagnostics.exists(b -> a != b && a.range != null && b.range != null && b.range.contains(a.range)));
 
 		return diagnostics;
+	}
+
+	function convertIndentation(msg:String, depth:Int):String {
+		if (msg.startsWith("... ")) {
+			msg = msg.substr(4);
+			depth++;
+		}
+
+		if (depth < 2)
+			return msg;
+
+		final buf = new StringBuf();
+		for (_ in 1...depth)
+			buf.add("⋅⋅⋅");
+		buf.add(" ");
+		buf.add(msg);
+		return buf.toString();
 	}
 
 	public function clearDiagnostics(uri:DocumentUri) {


### PR DESCRIPTION
Makes diagnostics display the same way as https://github.com/vshaxe/vshaxe/pull/587

Example:

![image](https://user-images.githubusercontent.com/6101998/236658182-2694f1d8-6931-48ad-a402-ad398670c677.png)
