### PR TITLE
Update ternary action

### DIFF
--- a/src/haxeLanguageServer/features/haxe/codeAction/ExtractVarFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/ExtractVarFeature.hx
@@ -306,8 +306,11 @@ class ExtractVarFeature implements CodeActionContributor {
 		var last = getLastToken(token);
 		if (last == null)
 			return last;
-		if (last.tok == Comma || last.tok == Semicolon)
-			last = last.previousSibling ?? last.parent;
+		if (last.tok == Comma || last.tok == Semicolon) {
+			last = last.previousSibling ?? return last.parent;
+			// [Dot(...), Semicolon] case
+			return getLastNonCommaToken(last);
+		}
 		return last;
 	}
 }


### PR DESCRIPTION
Works only on binop (`==`/`!=`) selection or after it in expr, don't want to iterate too much for it.
Also fix for ternary extraction to var.
```haxe
var foo = {name: null};
var bar = {name: 0};
foo.name = foo.name == null ? bar.name : foo.name;
foo.name = foo.name != null ? foo.name : bar.name;
foo.name = foo.name == null ? {
	name: 0
}.name : foo.name;
// should not work
foo.name = foo.name == null ? foo.name : bar.name;
foo.name = foo.name != null ? bar.name : foo.name;
```