### PR TITLE
Fix diagnostics code actions

### DIFF
--- a/src/haxeLanguageServer/features/haxe/DiagnosticsFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/DiagnosticsFeature.hx
@@ -183,6 +183,7 @@ class DiagnosticsFeature {
 					code: hxDiag.code,
 					severity: hxDiag.severity,
 					message: hxDiag.kind.getMessage(doc, hxDiag.args, range),
+					data: {kind: hxDiag.kind},
 					relatedInformation: hxDiag.relatedInformation?.map(rel -> {
 						location: {
 							uri: rel.location.file.toUri(),

--- a/src/haxeLanguageServer/features/haxe/codeAction/DiagnosticsCodeActionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/DiagnosticsCodeActionFeature.hx
@@ -34,10 +34,11 @@ class DiagnosticsCodeActionFeature implements CodeActionContributor {
 		}
 		var actions:Array<CodeAction> = [];
 		for (diagnostic in params.context.diagnostics) {
-			if (diagnostic.code == null || !(diagnostic.code is Int)) { // our codes are int, so we don't handle other stuff
+			final kind = diagnostic?.data?.kind;
+			if (kind == null || !(kind is Int)) { // our codes are int, so we don't handle other stuff
 				continue;
 			}
-			final code = new DiagnosticKind<T>(diagnostic.code);
+			final code = new DiagnosticKind<T>(kind);
 			actions = actions.concat(switch code {
 				case UnusedImport: UnusedImportActions.createUnusedImportActions(context, params, diagnostic);
 				case UnresolvedIdentifier: UnresolvedIdentifierActions.createUnresolvedIdentifierActions(context, params, diagnostic);


### PR DESCRIPTION
See https://github.com/vshaxe/haxe-language-server/pull/103

From Diagnostics type:
```haxe
/**
	A data entry field that is preserved between a `textDocument/publishDiagnostics`
	notification and `textDocument/codeAction` request.

	@since 3.16.0
**/
var ?data:LSPAny;
```