### PR TITLE
Add type hint action

### DIFF
--- a/src/haxeLanguageServer/Context.hx
+++ b/src/haxeLanguageServer/Context.hx
@@ -61,6 +61,7 @@ class Context {
 	@:nullSafety(Off) public var capabilities(default, null):ClientCapabilities;
 	@:nullSafety(Off) public var displayOffsetConverter(default, null):DisplayOffsetConverter;
 	@:nullSafety(Off) public var gotoDefinition(default, null):GotoDefinitionFeature;
+	@:nullSafety(Off) public var findReferences(default, null):FindReferencesFeature;
 	@:nullSafety(Off) public var determinePackage(default, null):DeterminePackageFeature;
 	@:nullSafety(Off) public var diagnostics(default, null):DiagnosticsFeature;
 
@@ -371,7 +372,7 @@ class Context {
 				gotoDefinition = new GotoDefinitionFeature(this);
 				new GotoImplementationFeature(this);
 				new GotoTypeDefinitionFeature(this);
-				new FindReferencesFeature(this);
+				findReferences = new FindReferencesFeature(this);
 				determinePackage = new DeterminePackageFeature(this);
 				new RenameFeature(this);
 				diagnostics = new DiagnosticsFeature(this);

--- a/src/haxeLanguageServer/features/haxe/FindReferencesFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/FindReferencesFeature.hx
@@ -15,7 +15,7 @@ class FindReferencesFeature {
 		context.languageServerProtocol.onRequest(ReferencesRequest.type, onFindReferences);
 	}
 
-	function onFindReferences(params:TextDocumentPositionParams, token:CancellationToken, resolve:Null<Array<Location>>->Void,
+	public function onFindReferences(params:TextDocumentPositionParams, token:CancellationToken, resolve:Null<Array<Location>>->Void,
 			reject:ResponseError<NoData>->Void) {
 		final uri = params.textDocument.uri;
 		final doc = context.documents.getHaxe(uri);

--- a/src/haxeLanguageServer/features/haxe/codeAction/DiagnosticsCodeActionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/DiagnosticsCodeActionFeature.hx
@@ -2,6 +2,7 @@ package haxeLanguageServer.features.haxe.codeAction;
 
 import haxeLanguageServer.features.haxe.DiagnosticsFeature;
 import haxeLanguageServer.features.haxe.codeAction.CodeActionFeature;
+import haxeLanguageServer.features.haxe.codeAction.diagnostics.AddTypeHintActions;
 import haxeLanguageServer.features.haxe.codeAction.diagnostics.CompilerErrorActions;
 import haxeLanguageServer.features.haxe.codeAction.diagnostics.FixAllAction;
 import haxeLanguageServer.features.haxe.codeAction.diagnostics.MissingFieldsActions;
@@ -51,6 +52,7 @@ class DiagnosticsCodeActionFeature implements CodeActionContributor {
 		}
 		actions = OrganizeImportActions.createOrganizeImportActions(context, params, actions).concat(actions);
 		actions = UpdateSyntaxActions.createUpdateSyntaxActions(context, params, actions).concat(actions);
+		actions = AddTypeHintActions.createAddTypeHintActions(context, params, actions).concat(actions);
 		actions = FixAllAction.createFixAllAction(context, params, actions).concat(actions);
 		actions = actions.filterDuplicates((a, b) -> a.title == b.title);
 		return actions;

--- a/src/haxeLanguageServer/features/haxe/codeAction/TokenTreeUtils.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/TokenTreeUtils.hx
@@ -16,6 +16,19 @@ class TokenTreeUtils {
 		return fun.tok.match(Kwd(KwdFunction));
 	}
 
+	public static function isFunctionArg(token:TokenTree):Bool {
+		final pOpen = token.parent ?? return false;
+		if (pOpen.tok != POpen)
+			return false;
+		final name = pOpen.parent ?? return false;
+		// `function() {}` or `() -> {}`
+		if (name.tok.match(Kwd(KwdFunction) | Arrow))
+			return true;
+		final fun = name.parent ?? return false;
+		// `function name() {}`
+		return fun.tok.match(Kwd(KwdFunction));
+	}
+
 	public static function isInLoopScope(token:TokenTree):Bool {
 		var kwd = token.parent ?? return false;
 		if (kwd.tok == BrOpen)

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/AddTypeHintActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/AddTypeHintActions.hx
@@ -1,0 +1,204 @@
+package haxeLanguageServer.features.haxe.codeAction.diagnostics;
+
+import haxe.display.Display.HoverDisplayItemOccurence;
+import haxeLanguageServer.helper.WorkspaceEditHelper;
+import js.lib.Promise;
+import jsonrpc.CancellationToken;
+import languageServerProtocol.Types.CodeAction;
+import languageServerProtocol.Types.DefinitionLink;
+import languageServerProtocol.Types.Diagnostic;
+import languageServerProtocol.Types.Location;
+import tokentree.TokenTree;
+
+class AddTypeHintActions {
+	public static function createAddTypeHintActions(context:Context, params:CodeActionParams, existingActions:Array<CodeAction>):Array<CodeAction> {
+		final uri = params.textDocument.uri;
+		final doc = context.documents.getHaxe(uri) ?? return [];
+		final actions:Array<CodeAction> = [];
+		final token = doc.tokens!.getTokenAtOffset(doc.offsetAt(params.range.end));
+		if (token == null)
+			return [];
+
+		if (token.isCIdent()) {
+			final isVarDecl = isVarDecl(token);
+			final isFunArg = TokenTreeUtils.isFunctionArg(token);
+			final isFunName = isFunctionName(token);
+			if (isVarDecl || isFunArg) {
+				// check type hint
+				final maybeColon = token.getFirstChild();
+				if (maybeColon != null && maybeColon.matches(DblDot)) {
+					return actions;
+				}
+			} else if (isFunName) {
+				// check return type hint
+				if (token.access().firstOf(DblDot) != null)
+					return actions;
+			} else {
+				return actions;
+			}
+		} else {
+			// action on `return` keyword
+			if (!TokenTreeUtils.isInFunctionScope(token))
+				return actions;
+			if (!token.tok.match(Kwd(KwdReturn)))
+				return actions;
+
+			final nameToken = token.parent!.parent ?? return actions;
+			// check return type hint
+			if (nameToken.access().firstOf(DblDot) != null)
+				return actions;
+			params.range = doc.rangeAt(nameToken.pos);
+		}
+
+		final data:CodeActionResolveData = {
+			type: AddTypeHint,
+			params: params,
+		};
+		actions.push({
+			title: "Add type hint",
+			data: data,
+			kind: RefactorRewrite,
+			isPreferred: false
+		});
+
+		return actions;
+	}
+
+	public static function createAddTypeHintAction(context:Context, action:CodeAction, params:CodeActionParams):Null<Promise<CodeAction>> {
+		if ((params.context.only != null) && (!params.context.only.contains(RefactorRewrite))) {
+			return null;
+		}
+		final document = context.documents.getHaxe(params.textDocument.uri);
+		if (document == null)
+			return null;
+		var tokenSource = new CancellationTokenSource();
+
+		final identToken = document.tokens!.getTokenAtOffset(document.offsetAt(params.range.end));
+		if (identToken == null)
+			return null;
+
+		final referencesPromise = new Promise(function(resolve:(locations:Array<Location>) -> Void, reject) {
+			context.findReferences.onFindReferences({
+				textDocument: params.textDocument,
+				position: document.positionAt(identToken.pos.min, Utf8)
+			}, tokenSource.token, array -> {
+				resolve(array ?? []);
+			}, error -> reject(error));
+		});
+
+		final gotoPromise = new Promise(function(resolve:(definitions:Array<DefinitionLink>) -> Void, reject) {
+			context.gotoDefinition.onGotoDefinition({
+				textDocument: params.textDocument,
+				position: document.positionAt(identToken.pos.min, Utf8)
+			}, tokenSource.token, array -> {
+				resolve(array);
+			}, error -> reject(error));
+		});
+
+		function makeHoverPromise<T>(loc:Location):Promise<Null<HoverDisplayItemOccurence<T>>> {
+			final fileName:String = loc.uri.toFsPath().toString();
+			final locDoc = context.documents.getHaxe(loc.uri) ?? return Promise.resolve();
+			var hoverPos = locDoc.offsetAt(loc.range.end) - 1;
+			return MissingArgumentsAction.makeHoverRequest(context, fileName, hoverPos, tokenSource.token);
+		}
+
+		final gotoAndHoverPromise = Promise.all([gotoPromise, referencesPromise]).then(results -> {
+			final definitions:Array<DefinitionLink> = results[0];
+			final definition = definitions[0] ?? cast return null;
+			final locations:Array<Location> = results[1];
+			// use latest location for best hover, or fallback to definition
+			final location = locations[locations.length - 1] ?? {
+				uri: definition.targetUri,
+				range: definition.targetSelectionRange
+			}
+				?? cast return null;
+			final locDoc = context.documents.getHaxe(location.uri) ?? cast return null;
+			final locToken = locDoc.tokens!.getTokenAtOffset(locDoc.offsetAt(location.range.end));
+			if (locToken == null)
+				return null;
+			final child = locToken.getFirstChild();
+			if (child != null) {
+				// hover on opAssign when available
+				// (`x = 1` is Int on hover, but `var x = 1` is not)
+				final isVarDecl = isVarDecl(locToken);
+				if (!isVarDecl && child.tok.match(Binop(OpAssign | OpAssignOp(_)))) {
+					location.range = locDoc.rangeAt(child.pos);
+				}
+			}
+
+			final hoverPromise = makeHoverPromise(location);
+			return Promise.all([Promise.resolve(gotoPromise), hoverPromise]);
+		});
+
+		final actionPromise = gotoAndHoverPromise.then(results -> {
+			final definitions:Array<DefinitionLink> = results[0];
+			final hover:HoverDisplayItemOccurence<Dynamic> = results[1];
+			final definition = definitions[0] ?? return action;
+			final defDoc = context.documents.getHaxe(definition.targetUri) ?? return action;
+			final defToken = defDoc.tokens!.getTokenAtOffset(defDoc.offsetAt(definition.targetSelectionRange.end));
+			// check if definition already has typehint
+			if (defToken == null || !defToken.isCIdent())
+				return action;
+			final maybeColon = defToken.getFirstChild();
+			if (maybeColon != null && maybeColon.matches(DblDot))
+				return action;
+
+			final isFunName = isFunctionName(defToken);
+			var typeHint = MissingArgumentsAction.printTypeHint(hover.item) ?? return action;
+			// trace(typeHint);
+			if (isFunName) {
+				// from: (arg, b:() -> Void) -> () -> Int
+				// to: () -> Int
+				typeHint = extractReturnType(typeHint);
+			}
+			if (typeHint == "?")
+				return action;
+			final range = if (isFunName) {
+				// add return type hint
+				final pOpen = defToken.access().firstOf(POpen).token ?? return action;
+				final pos = pOpen.getPos();
+				document.rangeAt(pos.max, pos.max, Utf8);
+			} else {
+				document.rangeAt(defToken.pos.max, defToken.pos.max, Utf8);
+			}
+
+			action.edit = WorkspaceEditHelper.create(defDoc, [{range: range, newText: ':$typeHint'}]);
+			return action;
+		});
+
+		return actionPromise;
+	}
+
+	static function isVarDecl(identToken:TokenTree):Bool {
+		final parent = identToken.parent ?? return false;
+		return parent.tok.match(Kwd(KwdVar | KwdFinal));
+	}
+
+	static function isFunctionName(nameToken:TokenTree):Bool {
+		final parent = nameToken.parent ?? return false;
+		return parent.tok.match(Kwd(KwdFunction));
+	}
+
+	static function extractReturnType(hint:String):String {
+		if (hint.length == 0 || hint.charCodeAt(0) != "(".code)
+			return hint;
+		var pOpens = 0;
+		for (i => code in hint) {
+			switch code {
+				case "(".code:
+					pOpens++;
+				case ")".code:
+					pOpens--;
+					if (pOpens != 0)
+						continue;
+					final part = hint.substr(i + 1).trim();
+					if (part.startsWith("->")) {
+						return part.substr(2).ltrim();
+					} else {
+						return hint;
+					}
+			}
+		}
+		return hint;
+	}
+}

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ChangeFinalToVarAction.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ChangeFinalToVarAction.hx
@@ -19,7 +19,7 @@ class ChangeFinalToVarAction {
 		final varToken = document.tokens!.getTokenAtOffset(document.offsetAt(diagnostic.range.start));
 		if (varToken == null)
 			return null;
-		final gotoPromise = new Promise(function(resolve:(hover:Array<DefinitionLink>) -> Void, reject) {
+		final gotoPromise = new Promise(function(resolve:(definitions:Array<DefinitionLink>) -> Void, reject) {
 			context.gotoDefinition.onGotoDefinition({
 				textDocument: params.textDocument,
 				position: document.positionAt(varToken.pos.min, Utf8)

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/CompilerErrorActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/CompilerErrorActions.hx
@@ -72,8 +72,6 @@ class CompilerErrorActions {
 
 		final tooManyArgsRe = ~/Too many arguments([\w.]*)/;
 		if (tooManyArgsRe.match(arg)) {
-			final document = context.documents.getHaxe(params.textDocument.uri);
-			final replacement = document.getText(diagnostic.range);
 			final data:CodeActionResolveData = {
 				type: MissingArg,
 				params: params,
@@ -89,8 +87,6 @@ class CompilerErrorActions {
 		}
 
 		if (arg.contains("Cannot assign to final") || arg.contains("This expression cannot be accessed for writing")) {
-			final document = context.documents.getHaxe(params.textDocument.uri);
-			final replacement = document.getText(diagnostic.range);
 			final data:CodeActionResolveData = {
 				type: ChangeFinalToVar,
 				params: params,

--- a/test/DisplayTestContext.hx
+++ b/test/DisplayTestContext.hx
@@ -3,6 +3,7 @@ import haxeLanguageServer.Configuration;
 import haxeLanguageServer.Context;
 import haxeLanguageServer.documents.HaxeDocument;
 import haxeLanguageServer.features.haxe.DiagnosticsFeature;
+import haxeLanguageServer.features.haxe.FindReferencesFeature;
 import haxeLanguageServer.features.haxe.GotoDefinitionFeature;
 import haxeLanguageServer.helper.DisplayOffsetConverter;
 import haxeLanguageServer.helper.SemVer;
@@ -54,6 +55,7 @@ class DisplayTestContext {
 		docs[uri] = doc;
 
 		context.gotoDefinition = new GotoDefinitionFeature(context);
+		context.findReferences = new FindReferencesFeature(context);
 		context.displayOffsetConverter = DisplayOffsetConverter.create(context.haxeServer.haxeVersion);
 	}
 

--- a/test/codeActions/AddMissingArgsTest.hx
+++ b/test/codeActions/AddMissingArgsTest.hx
@@ -83,6 +83,7 @@ class AddMissingArgsTest extends DisplayTestCase {
 			function pickAndApply(callback:() -> Void):Void {
 				if (ranges.length == 0) {
 					callback();
+					return;
 				}
 				final range = ranges.shift();
 				final params = codeActionParams(range);

--- a/test/codeActions/AddTypeHintActionsTest.hx
+++ b/test/codeActions/AddTypeHintActionsTest.hx
@@ -1,0 +1,88 @@
+package codeActions;
+
+import haxeLanguageServer.features.haxe.codeAction.diagnostics.AddTypeHintActions;
+import haxeLanguageServer.features.haxe.codeAction.diagnostics.MissingArgumentsAction;
+import js.lib.Promise;
+
+@:access(haxeLanguageServer.features.haxe.codeAction.diagnostics.MissingArgumentsAction)
+class AddTypeHintActionsTest extends DisplayTestCase {
+	/**
+		class Main {
+			final conf{-5-}ig = {
+				x: 1,
+				y: foo(0)
+			}
+			static function main() {
+				final a{-4-}rr = [];
+				arr.push(0);
+				final first = arr[0];
+				final co{-3-}rds = [{
+					x: 0.0,
+					y: 0.0,
+					scale: 0.5
+				}];
+			}
+			static function f{-1-}oo(a{-2-}rg, ?b:()->Void) {
+				arg += 1;
+				return () -> 1;
+			}
+		}
+		---
+		class Main {
+			final config:{x:Int, y:() -> Int} = {
+				x: 1,
+				y: foo(0)
+			}
+			static function main() {
+				final arr:Array<Int> = [];
+				arr.push(0);
+				final first = arr[0];
+				final cords:Array<{x:Float, y:Float, scale:Float}> = [{
+					x: 0.0,
+					y: 0.0,
+					scale: 0.5
+				}];
+			}
+			static function foo(arg:Int, ?b:()->Void):() -> Int {
+				arg += 1;
+				return () -> 1;
+			}
+		}
+	**/
+	@:timeout(500)
+	function test(async:utest.Async) {
+		ctx.cacheFile();
+		ctx.startServer(() -> {
+			var action:CodeAction = {title: ""};
+			final ranges = [
+				for (i in 1...6)
+					range(i, i)
+			];
+
+			function pickAndApply(callback:() -> Void):Void {
+				if (ranges.length == 0) {
+					callback();
+					return;
+				}
+				final range = ranges.shift();
+				final params = codeActionParams(range);
+				// final diag = createDiagnostic(range);
+				final action = AddTypeHintActions.createAddTypeHintAction(ctx.context, action, params);
+				assert(action != null);
+				action.then(action -> {
+					applyTextEdit(action.edit);
+					pickAndApply(callback);
+				}, (err) -> {
+					ctx.removeCacheFile();
+					throw err;
+				});
+			}
+
+			pickAndApply(() -> {
+				eq(ctx.result, ctx.doc.content);
+				ctx.removeCacheFile();
+				async.done();
+			});
+		});
+	}
+}


### PR DESCRIPTION
Works on `config`/`arr`/`cords`/`foo`/`arg`/`return` and etc
```haxe
class Main {
	final config = {
		x: 1,
		y: foo(0)
	}
	static function main() {
		final arr = [];
		arr.push(0);
		final first = arr[0];
		final cords = [{
			x: 0.0,
			y: 0.0,
			scale: 0.5
		}];
	}
	static function foo(arg, ?b:()->Void) {
		arg += 1;
		return () -> 1;
	}
}

```