### PR TITLE
CodeActionFeature: fix crash when calling contains() on null capabilities value

### DIFF
--- a/src/haxeLanguageServer/features/haxe/codeAction/CodeActionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/CodeActionFeature.hx
@@ -48,7 +48,8 @@ class CodeActionFeature {
 			],
 			resolveProvider: true
 		});
-		hasCommandResolveSupport = context.capabilities.textDocument!.codeAction!.resolveSupport!.properties.contains("command");
+		var resolveSupportProperties = context.capabilities.textDocument!.codeAction!.resolveSupport!.properties;
+		hasCommandResolveSupport = resolveSupportProperties != null ? resolveSupportProperties.contains("command") : false;
 		context.languageServerProtocol.onRequest(CodeActionRequest.type, onCodeAction);
 		context.languageServerProtocol.onRequest(CodeActionResolveRequest.type, onCodeActionResolve);
 


### PR DESCRIPTION
This code may fail if `properties` (or any value up the chain) is null.

```
context.capabilities.textDocument!.codeAction!.resolveSupport!.properties.contains("command")
```

I tried `properties!.contains("command")`, but it wouldn't compile. So I saved `properties` to a local variable and checked if the local variable was null or not before calling `contains()`.