### PR TITLE
[CI] Alternative build/test without lix/vshaxe-build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Avoid differences between unix and windows CI there
+install.hxml text eol=crlf

--- a/.github/workflows/main-vanilla.yml
+++ b/.github/workflows/main-vanilla.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI - Vanilla
 
 on: [push, pull_request]
 

--- a/.github/workflows/main-vanilla.yml
+++ b/.github/workflows/main-vanilla.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        haxe: [latest, "2024-11-27_development_2dc801f"]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: krdlab/setup-haxe@v1
+      with:
+        haxe-version: ${{ matrix.haxe }}
+
+    - name: Install dependencies
+      run: |
+        npm ci
+        haxelib newrepo
+        haxelib state load install.hxml
+
+    - name: Check dependencies
+      run: |
+        haxe -version
+        haxelib list
+
+    - name: Build Haxe LSP
+      run: haxe build.hxml
+
+    - name: Run tests
+      run: haxe test.hxml

--- a/.github/workflows/main-vanilla.yml
+++ b/.github/workflows/main-vanilla.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: krdlab/setup-haxe@v1
+    - uses: krdlab/setup-haxe@master
       with:
         haxe-version: ${{ matrix.haxe }}
 

--- a/.github/workflows/main-vanilla.yml
+++ b/.github/workflows/main-vanilla.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         haxe: [latest, "2024-11-27_development_2dc801f"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/main-vanilla.yml
+++ b/.github/workflows/main-vanilla.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Install npm dependencies
       run: |
-        npm ci
+        npm i terser
 
     - name: Install haxelib dependencies
       if: steps.cache-haxelib.outputs.cache-hit != 'true'

--- a/.github/workflows/main-vanilla.yml
+++ b/.github/workflows/main-vanilla.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Install npm dependencies
       run: |
-        npm i terser
+        npm ci --ignore-scripts
 
     - name: Install haxelib dependencies
       if: steps.cache-haxelib.outputs.cache-hit != 'true'

--- a/.github/workflows/main-vanilla.yml
+++ b/.github/workflows/main-vanilla.yml
@@ -17,9 +17,20 @@ jobs:
       with:
         haxe-version: ${{ matrix.haxe }}
 
-    - name: Install dependencies
+    - name: Cache haxelib
+      id: cache-haxelib
+      uses: actions/cache@v3.0.11
+      with:
+        path: .haxelib
+        key: ${{ hashFiles('./install.hxml') }}
+
+    - name: Install npm dependencies
       run: |
         npm ci
+
+    - name: Install haxelib dependencies
+      if: steps.cache-haxelib.outputs.cache-hit != 'true'
+      run: |
         haxelib newrepo
         haxelib state load install.hxml
 

--- a/.github/workflows/main-vanilla.yml
+++ b/.github/workflows/main-vanilla.yml
@@ -7,7 +7,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        # TODO: fix tests on windows and enable again
+        # os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-13]
         haxe: [latest, "2024-11-27_development_2dc801f"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.hxml
+++ b/build.hxml
@@ -1,0 +1,29 @@
+-lib hxnodejs
+-lib hxparse
+-lib haxeparser
+-lib tokentree
+-lib formatter
+-lib rename
+-lib json2object
+-lib language-server-protocol
+-lib vscode-json-rpc
+-lib uglifyjs
+-lib safety
+
+-cp src
+-cp shared
+
+-D analyzer-optimize
+-D js-unflatten
+-D js-es=6
+-D JSTACK_FORMAT=vscode
+-D uglifyjs_overwrite
+--dce full
+--debug
+
+--macro haxeLanguageServer.Init.run()
+--macro Safety.safeNavigation('haxeLanguageServer')
+--macro nullSafety('haxeLanguageServer')
+
+-js bin/server.js
+-main haxeLanguageServer.Main

--- a/install.hxml
+++ b/install.hxml
@@ -1,0 +1,15 @@
+-lib uglifyjs:1.0.0
+-lib formatter:1.18.0
+-lib haxeparser:git:https://github.com/HaxeCheckstyle/haxeparser#a5fce2ecf5fb3bdfebfd7efd8b05329d456ec0d2
+-lib hxparse:git:https://github.com/simn/hxparse#876070ec62a4869de60081f87763e23457a3bda8
+-lib json2object:git:https://github.com/elnabo/json2object#a75859de1e966c09e73591b6c9186086c143fe60
+-lib test-adapter:2.0.7
+-lib utest:git:https://github.com/haxe-utest/utest#bdb5fec4b8e77d9a3c079d9cfb108f29f153721a
+-lib hxnodejs:git:https://github.com/HaxeFoundation/hxnodejs#504066d
+-lib tokentree:1.2.17
+-lib language-server-protocol:git:https://github.com/vshaxe/language-server-protocol-haxe#a6baa2ddcd792e99b19398048ef95aa00f0aa1f6
+-lib hxjsonast:1.1.0
+-lib vscode-json-rpc:git:https://github.com/vshaxe/vscode-json-rpc#0160f06bc9df1dd0547f2edf23753540db74ed5b
+-lib rename:3.0.0
+-lib vshaxe-build:git:https://github.com/vshaxe/vshaxe-build#39ab9c6315ae76080e5399391c8fa561daec6d55
+-lib safety:1.1.2

--- a/test.hxml
+++ b/test.hxml
@@ -1,0 +1,27 @@
+-lib hxnodejs
+-lib hxparse
+-lib haxeparser
+-lib tokentree
+-lib formatter
+-lib rename
+-lib json2object
+-lib language-server-protocol
+-lib vscode-json-rpc
+-lib safety
+-lib utest
+
+-cp src
+-cp shared
+-cp test
+
+--macro Safety.safeNavigation('haxeLanguageServer')
+
+-D analyzer-optimize
+-D js-unflatten
+-D js-es=6
+--dce full
+--debug
+
+-main TestMain
+-js bin/test.js
+-cmd node bin/test.js

--- a/test/codeActions/AddMissingArgsTest.hx
+++ b/test/codeActions/AddMissingArgsTest.hx
@@ -66,7 +66,7 @@ class AddMissingArgsTest extends DisplayTestCase {
 		function foo10(arg:Bytes) {}
 		function foo11(arg:Bytes) {}
 	**/
-	@:timeout(500)
+	@:timeout(10000)
 	function test(async:utest.Async) {
 		ctx.cacheFile();
 		ctx.startServer(() -> {
@@ -155,7 +155,7 @@ class AddMissingArgsTest extends DisplayTestCase {
 			public function new(i:Int) {}
 		}
 	**/
-	@:timeout(500)
+	@:timeout(1000)
 	function testConstructorArg(async:utest.Async) {
 		ctx.cacheFile();
 		ctx.startServer(() -> {

--- a/test/codeActions/AddTypeHintActionsTest.hx
+++ b/test/codeActions/AddTypeHintActionsTest.hx
@@ -49,7 +49,7 @@ class AddTypeHintActionsTest extends DisplayTestCase {
 			}
 		}
 	**/
-	@:timeout(500)
+	@:timeout(5000)
 	function test(async:utest.Async) {
 		ctx.cacheFile();
 		ctx.startServer(() -> {


### PR DESCRIPTION
* No longer removing lix/vshaxe-build, just providing alternative
* Outdated libs should make CI fail pretty much all the time without adding another check
* Updating `install.hxml` locally can be done with [haxe-manager](https://github.com/kLabz/haxe-manager)'s `hx lix-to-install install.hxml`
* CI is now also running on latest Haxe nightlies to detect issues earlier
* CI is now also running on mac ~~and windows~~ (CI is [disabled](https://github.com/vshaxe/haxe-language-server/pull/122/commits/6c261595701b2455909dd9d7062451973ef19eab) on windows for now because tests have been broken there for a while)
* Note: had to [increase timeout](https://github.com/vshaxe/haxe-language-server/pull/122/commits/5e598b89c309936645e8b9910cc1ad4d281b3735) on a few tests because of slow macos runners hitting timeout there