### PR TITLE
Json rpc diagnostics

### DIFF
--- a/.haxerc
+++ b/.haxerc
@@ -1,4 +1,4 @@
 {
-  "version": "569e52e",
+  "version": "15abdcc",
   "resolveLibs": "scoped"
 }

--- a/src/haxeLanguageServer/Configuration.hx
+++ b/src/haxeLanguageServer/Configuration.hx
@@ -94,7 +94,6 @@ typedef UserConfig = {
 	var buildCompletionCache:Bool;
 	var enableCompletionCacheWarning:Bool;
 	var useLegacyCompletion:Bool;
-	var populateCacheFromDisplay:Bool;
 	var codeGeneration:CodeGenerationConfig;
 	var exclude:Array<String>;
 	var postfixCompletion:PostfixCompletionConfig;
@@ -162,7 +161,6 @@ class Configuration {
 		displayPort: null,
 		buildCompletionCache: true,
 		enableCompletionCacheWarning: true,
-		populateCacheFromDisplay: true,
 		useLegacyCompletion: false,
 		codeGeneration: {
 			functions: {

--- a/src/haxeLanguageServer/Configuration.hx
+++ b/src/haxeLanguageServer/Configuration.hx
@@ -88,6 +88,7 @@ typedef UserConfig = {
 	var enableDiagnostics:Bool;
 	var enableServerView:Bool;
 	var enableSignatureHelpDocumentation:Bool;
+	var diagnosticsForAllOpenFiles:Bool;
 	var diagnosticsPathFilter:String;
 	var displayHost:String;
 	var displayPort:EitherType<Int, String>;
@@ -156,6 +157,7 @@ class Configuration {
 		enableDiagnostics: true,
 		enableServerView: false,
 		enableSignatureHelpDocumentation: true,
+		diagnosticsForAllOpenFiles: true,
 		diagnosticsPathFilter: "${workspaceRoot}",
 		displayHost: null,
 		displayPort: null,

--- a/src/haxeLanguageServer/features/haxe/DiagnosticsFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/DiagnosticsFeature.hx
@@ -69,10 +69,11 @@ class DiagnosticsFeature {
 		} else {
 			context.callDisplay("global diagnostics", ["diagnostics"], null, null, function(result) {
 				final data = parseLegacyDiagnostics(result);
-				if (data == null)
+				if (data == null) {
 					clearDiagnosticsOnClient(errorUri);
-				else
+				} else {
 					processDiagnosticsReply(null, onResolve, data);
+				}
 				context.languageServerProtocol.sendNotification(LanguageServerMethods.DidRunRunGlobalDiagnostics);
 				stopProgress();
 			}, function(error) {
@@ -337,8 +338,9 @@ class DiagnosticsFeature {
 				if (context.config.user.diagnosticsForAllOpenFiles) {
 					context.documents.iter(function(doc) {
 						final path = doc.uri.toFsPath();
-						if (doc.languageId == "haxe" && !isPathFiltered(path))
+						if (doc.languageId == "haxe" && !isPathFiltered(path)) {
 							params.fileContents.sure().push({file: path, contents: null});
+						}
 					});
 				} else {
 					params.file = doc.uri.toFsPath();
@@ -356,10 +358,11 @@ class DiagnosticsFeature {
 				context.callDisplay("@diagnostics", [doc.uri.toFsPath() + "@0@diagnostics"], null, token, result -> {
 					pendingRequests.remove(uri);
 					final data = parseLegacyDiagnostics(result);
-					if (data == null)
+					if (data == null) {
 						clearDiagnosticsOnClient(errorUri);
-					else
+					} else {
 						processDiagnosticsReply(null, onResolve, data);
+					}
 				}, error -> {
 					pendingRequests.remove(uri);
 					processErrorReply(uri, error);
@@ -372,8 +375,9 @@ class DiagnosticsFeature {
 
 	function cancelPendingRequest(uri:DocumentUri) {
 		if (useJsonRpc && context.config.user.diagnosticsForAllOpenFiles) {
-			for (tokenSource in pendingRequests)
+			for (tokenSource in pendingRequests) {
 				tokenSource.cancel();
+			}
 			pendingRequests.clear();
 		} else {
 			var tokenSource = pendingRequests[uri];

--- a/src/haxeLanguageServer/features/haxe/DiagnosticsFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/DiagnosticsFeature.hx
@@ -1,5 +1,7 @@
 package haxeLanguageServer.features.haxe;
 
+import haxe.display.Diagnostic;
+import haxe.display.Display.DisplayMethods;
 import haxe.Json;
 import haxe.display.JsonModuleTypes;
 import haxe.ds.BalancedTree;
@@ -13,10 +15,10 @@ import js.Node.setImmediate;
 import js.node.ChildProcess;
 import jsonrpc.CancellationToken;
 import languageServerProtocol.Types.Diagnostic;
-import languageServerProtocol.Types.DiagnosticSeverity;
 import languageServerProtocol.Types.Location;
 
 using Lambda;
+using haxeLanguageServer.features.haxe.DiagnosticsFeature;
 
 class DiagnosticsFeature {
 	public static inline final SortImportsUsingsTitle = "Sort imports/usings";
@@ -45,12 +47,13 @@ class DiagnosticsFeature {
 
 	function onRunGlobalDiagnostics(_) {
 		final stopProgress = context.startProgress("Collecting Diagnostics");
-		final onResolve = context.startTimer("@diagnostics");
+		final onResolve = context.startTimer("display/diagnostics");
 
-		context.callDisplay("global diagnostics", ["diagnostics"], null, null, function(result) {
+		context.callHaxeMethod(DisplayMethods.Diagnostics, {}, null, result -> {
 			processDiagnosticsReply(null, onResolve, result);
 			context.languageServerProtocol.sendNotification(LanguageServerMethods.DidRunRunGlobalDiagnostics);
 			stopProgress();
+			return null;
 		}, function(error) {
 			processErrorReply(null, error);
 			stopProgress();
@@ -108,7 +111,7 @@ class DiagnosticsFeature {
 
 		final diag = {
 			range: {start: position, end: endPosition},
-			severity: DiagnosticSeverity.Error,
+			severity: languageServerProtocol.Types.DiagnosticSeverity.Error,
 			message: problemMatcher.matched(7)
 		};
 		publishDiagnostic(targetUri, diag, error);
@@ -122,7 +125,7 @@ class DiagnosticsFeature {
 		}
 		final diag = {
 			range: {start: {line: 0, character: 0}, end: {line: 0, character: 0}},
-			severity: DiagnosticSeverity.Error,
+			severity: languageServerProtocol.Types.DiagnosticSeverity.Error,
 			message: problemMatcher.matched(2)
 		};
 		publishDiagnostic(errorUri, diag, error);
@@ -132,22 +135,11 @@ class DiagnosticsFeature {
 	function publishDiagnostic(uri:DocumentUri, diag:Diagnostic, error:String) {
 		context.languageServerProtocol.sendNotification(PublishDiagnosticsNotification.type, {uri: uri, diagnostics: [diag]});
 		final argumentsMap = diagnosticsArguments[uri] = new DiagnosticsMap();
-		argumentsMap.set({code: CompilerError, range: diag.range}, error);
+		argumentsMap.set({code: DKCompilerError, range: diag.range}, error);
 	}
 
-	function processDiagnosticsReply(uri:Null<DocumentUri>, onResolve:(result:Dynamic, ?debugInfo:String) -> Void, result:DisplayResult) {
+	function processDiagnosticsReply(uri:Null<DocumentUri>, onResolve:(result:Dynamic, ?debugInfo:String) -> Void, data:ReadOnlyArray<{ file : haxe.display.FsPath, diagnostics : ReadOnlyArray<haxe.display.Diagnostic<Any>> }>) {
 		clearDiagnosticsOnClient(errorUri);
-		final data:Array<HaxeDiagnosticResponse<Any>> = switch result {
-			case DResult(s):
-				try {
-					Json.parse(s);
-				} catch (e) {
-					trace("Error parsing diagnostics response: " + e);
-					return;
-				}
-			case DCancelled:
-				return;
-		}
 		var count = 0;
 		final sent = new Map<DocumentUri, Bool>();
 		for (data in data) {
@@ -181,7 +173,7 @@ class DiagnosticsFeature {
 				final diag:Diagnostic = {
 					range: range,
 					code: hxDiag.code,
-					severity: hxDiag.severity,
+					severity: cast hxDiag.severity,
 					message: hxDiag.kind.getMessage(doc, hxDiag.args, range),
 					data: {kind: hxDiag.kind},
 					relatedInformation: hxDiag.relatedInformation?.map(rel -> {
@@ -192,7 +184,7 @@ class DiagnosticsFeature {
 						message: convertIndentation(rel.message, rel.depth)
 					})
 				}
-				if (kind == ReplaceableCode || kind == UnusedImport || diag.message.contains("has no effect") || kind == InactiveBlock) {
+				if (kind == ReplacableCode || kind == DKUnusedImport || diag.message.contains("has no effect") || kind == InactiveBlock) {
 					diag.severity = Hint;
 					diag.tags = [Unnecessary];
 				}
@@ -229,23 +221,23 @@ class DiagnosticsFeature {
 		return !PathHelper.matches(path, pathFilter);
 	}
 
-	function filterRelevantDiagnostics(diagnostics:Array<HaxeDiagnostic<Any>>):Array<HaxeDiagnostic<Any>> {
+	function filterRelevantDiagnostics(diagnostics:ReadOnlyArray<HaxeDiagnostic<Any>>):ReadOnlyArray<HaxeDiagnostic<Any>> {
 		// hide regular compiler errors while there's parser errors, they can be misleading
 		final hasProblematicParserErrors = diagnostics.find(d -> switch (d.kind : Int) {
-			case ParserError: d.args != "Missing ;"; // don't be too strict
+			case DKParserError: d.args != "Missing ;"; // don't be too strict
 			case _: false;
 		}) != null;
 		if (hasProblematicParserErrors) {
 			diagnostics = diagnostics.filter(d -> switch (d.kind : Int) {
-				case CompilerError, UnresolvedIdentifier: false;
+				case DKCompilerError, DKUnresolvedIdentifier: false;
 				case _: true;
 			});
 		}
 
 		// hide unused import warnings while there's compiler errors (to avoid false positives)
-		final hasCompilerErrors = diagnostics.find(d -> d.kind == cast CompilerError) != null;
+		final hasCompilerErrors = diagnostics.find(d -> d.kind == cast DKCompilerError) != null;
 		if (hasCompilerErrors) {
-			diagnostics = diagnostics.filter(d -> d.kind != cast UnusedImport);
+			diagnostics = diagnostics.filter(d -> d.kind != cast DKUnusedImport);
 		}
 
 		// hide inactive blocks that are contained within other inactive blocks
@@ -301,10 +293,11 @@ class DiagnosticsFeature {
 	function invokePendingRequest(uri:DocumentUri, token:CancellationToken) {
 		final doc:Null<HaxeDocument> = context.documents.getHaxe(uri);
 		if (doc != null) {
-			final onResolve = context.startTimer("@diagnostics");
-			context.callDisplay("@diagnostics", [doc.uri.toFsPath() + "@0@diagnostics"], null, token, result -> {
+			final onResolve = context.startTimer("display/diagnostics");
+			context.callHaxeMethod(DisplayMethods.Diagnostics, {file: doc.uri.toFsPath()}, token, result -> {
 				pendingRequests.remove(uri);
 				processDiagnosticsReply(uri, onResolve, result);
+				return null;
 			}, error -> {
 				pendingRequests.remove(uri);
 				processErrorReply(uri, error);
@@ -333,79 +326,21 @@ class DiagnosticsFeature {
 	}
 }
 
-enum abstract UnresolvedIdentifierSuggestion(Int) {
-	final Import;
-	final Typo;
-}
+class DiagnosticKindHelper {
+	public static function make<T>(code:Int) return (code:DiagnosticKind<T>);
 
-enum abstract MissingFieldCauseKind<T>(String) {
-	final AbstractParent:MissingFieldCauseKind<{parent:JsonTypePathWithParams}>;
-	final ImplementedInterface:MissingFieldCauseKind<{parent:JsonTypePathWithParams}>;
-	final PropertyAccessor:MissingFieldCauseKind<{property:JsonClassField, isGetter:Bool}>;
-	final FieldAccess:MissingFieldCauseKind<{}>;
-	final FinalFields:MissingFieldCauseKind<{fields:Array<JsonClassField>}>;
-}
-
-typedef MissingFieldCause<T> = {
-	var kind:MissingFieldCauseKind<T>;
-	var args:T;
-}
-
-typedef MissingField = {
-	var field:JsonClassField;
-	var type:JsonType<Dynamic>;
-
-	/**
-		When implementing multiple interfaces, there can be field duplicates among them. This flag is only
-		true for the first such occurrence of a field, so that the "Implement all" code action doesn't end
-		up implementing the same field multiple times.
-	**/
-	var unique:Bool;
-}
-
-typedef MissingFieldDiagnostic = {
-	var fields:Array<MissingField>;
-	var cause:MissingFieldCause<Dynamic>;
-}
-
-typedef MissingFieldDiagnostics = {
-	var moduleType:JsonModuleType<Dynamic>;
-	var moduleFile:String;
-	var entries:Array<MissingFieldDiagnostic>;
-}
-
-typedef ReplaceableCode = {
-	var description:String;
-	var range:Range;
-	var ?newCode:String;
-}
-
-enum abstract DiagnosticKind<T>(Int) from Int to Int {
-	final UnusedImport:DiagnosticKind<Void>;
-	final UnresolvedIdentifier:DiagnosticKind<Array<{kind:UnresolvedIdentifierSuggestion, name:String}>>;
-	final CompilerError:DiagnosticKind<String>;
-	final ReplaceableCode:DiagnosticKind<ReplaceableCode>;
-	final ParserError:DiagnosticKind<String>;
-	final DeprecationWarning:DiagnosticKind<String>;
-	final InactiveBlock:DiagnosticKind<Void>;
-	final MissingFields:DiagnosticKind<MissingFieldDiagnostics>;
-
-	public inline function new(i:Int) {
-		this = i;
-	}
-
-	public function getMessage(doc:Null<HaxeDocument>, args:T, range:Range) {
-		return switch (this : DiagnosticKind<T>) {
-			case UnusedImport: "Unused import/using";
-			case UnresolvedIdentifier:
+	public static function getMessage<T>(dk:DiagnosticKind<T>, doc:Null<HaxeDocument>, args:T, range:Range) {
+		return switch dk {
+			case DKUnusedImport: "Unused import/using";
+			case DKUnresolvedIdentifier:
 				var message = 'Unknown identifier';
 				if (doc != null) {
 					message += ' : ${doc.getText(range)}';
 				}
 				message;
-			case CompilerError: args.trim();
-			case ReplaceableCode: args.description;
-			case ParserError: args;
+			case DKCompilerError: args.trim();
+			case ReplacableCode: args.description;
+			case DKParserError: args;
 			case DeprecationWarning: args;
 			case InactiveBlock: "Inactive conditional compilation block";
 			case MissingFields:

--- a/src/haxeLanguageServer/features/haxe/DiagnosticsFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/DiagnosticsFeature.hx
@@ -68,8 +68,10 @@ class DiagnosticsFeature {
 		} else {
 			context.callDisplay("global diagnostics", ["diagnostics"], null, null, function(result) {
 				final data = parseLegacyDiagnostics(result);
-				if (data == null) clearDiagnosticsOnClient(errorUri);
-				else processDiagnosticsReply(null, onResolve, data);
+				if (data == null)
+					clearDiagnosticsOnClient(errorUri);
+				else
+					processDiagnosticsReply(null, onResolve, data);
 				context.languageServerProtocol.sendNotification(LanguageServerMethods.DidRunRunGlobalDiagnostics);
 				stopProgress();
 			}, function(error) {
@@ -79,7 +81,7 @@ class DiagnosticsFeature {
 		}
 	}
 
-	function parseLegacyDiagnostics(result:DisplayResult):Null<ReadOnlyArray<{ file : haxe.display.FsPath, diagnostics : ReadOnlyArray<haxe.display.Diagnostic<Any>> }>> {
+	function parseLegacyDiagnostics(result:DisplayResult):Null<ReadOnlyArray<{file:haxe.display.FsPath, diagnostics:ReadOnlyArray<haxe.display.Diagnostic<Any>>}>> {
 		return switch result {
 			case DResult(s):
 				try {
@@ -170,7 +172,8 @@ class DiagnosticsFeature {
 		argumentsMap.set({code: DKCompilerError, range: diag.range}, error);
 	}
 
-	function processDiagnosticsReply(uri:Null<DocumentUri>, onResolve:(result:Dynamic, ?debugInfo:String) -> Void, data:ReadOnlyArray<{ file : haxe.display.FsPath, diagnostics : ReadOnlyArray<haxe.display.Diagnostic<Any>> }>) {
+	function processDiagnosticsReply(uri:Null<DocumentUri>, onResolve:(result:Dynamic, ?debugInfo:String) -> Void,
+			data:ReadOnlyArray<{file:haxe.display.FsPath, diagnostics:ReadOnlyArray<haxe.display.Diagnostic<Any>>}>) {
 		clearDiagnosticsOnClient(errorUri);
 		var count = 0;
 		final sent = new Map<DocumentUri, Bool>();
@@ -339,8 +342,10 @@ class DiagnosticsFeature {
 				context.callDisplay("@diagnostics", [doc.uri.toFsPath() + "@0@diagnostics"], null, token, result -> {
 					pendingRequests.remove(uri);
 					final data = parseLegacyDiagnostics(result);
-					if (data == null) clearDiagnosticsOnClient(errorUri);
-					else processDiagnosticsReply(null, onResolve, data);
+					if (data == null)
+						clearDiagnosticsOnClient(errorUri);
+					else
+						processDiagnosticsReply(null, onResolve, data);
 				}, error -> {
 					pendingRequests.remove(uri);
 					processErrorReply(uri, error);
@@ -371,7 +376,8 @@ class DiagnosticsFeature {
 }
 
 class DiagnosticKindHelper {
-	public static function make<T>(code:Int) return (code:DiagnosticKind<T>);
+	public static function make<T>(code:Int)
+		return (code : DiagnosticKind<T>);
 
 	public static function getMessage<T>(dk:DiagnosticKind<T>, doc:Null<HaxeDocument>, args:T, range:Range) {
 		return switch dk {

--- a/src/haxeLanguageServer/features/haxe/DiagnosticsFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/DiagnosticsFeature.hx
@@ -219,7 +219,7 @@ class DiagnosticsFeature {
 						message: convertIndentation(rel.message, rel.depth)
 					})
 				}
-				if (kind == ReplacableCode || kind == DKUnusedImport || diag.message.contains("has no effect") || kind == InactiveBlock) {
+				if (kind == ReplaceableCode || kind == DKUnusedImport || diag.message.contains("has no effect") || kind == InactiveBlock) {
 					diag.severity = Hint;
 					diag.tags = [Unnecessary];
 				}
@@ -389,7 +389,7 @@ class DiagnosticKindHelper {
 				}
 				message;
 			case DKCompilerError: args.trim();
-			case ReplacableCode: args.description;
+			case ReplaceableCode: args.description;
 			case DKParserError: args;
 			case DeprecationWarning: args;
 			case InactiveBlock: "Inactive conditional compilation block";

--- a/src/haxeLanguageServer/features/haxe/codeAction/DiagnosticsCodeActionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/DiagnosticsCodeActionFeature.hx
@@ -45,7 +45,7 @@ class DiagnosticsCodeActionFeature implements CodeActionContributor {
 				case DKUnusedImport: UnusedImportActions.createUnusedImportActions(context, params, diagnostic);
 				case DKUnresolvedIdentifier: UnresolvedIdentifierActions.createUnresolvedIdentifierActions(context, params, diagnostic);
 				case DKCompilerError: CompilerErrorActions.createCompilerErrorActions(context, params, diagnostic);
-				case ReplacableCode: ReplaceableCodeActions.createReplaceableCodeActions(context, params, diagnostic);
+				case ReplaceableCode: ReplaceableCodeActions.createReplaceableCodeActions(context, params, diagnostic);
 				case DKParserError: ParserErrorActions.createParserErrorActions(context, params, diagnostic);
 				case MissingFields: MissingFieldsActions.createMissingFieldsActions(context, params, diagnostic);
 				case _: [];

--- a/src/haxeLanguageServer/features/haxe/codeAction/DiagnosticsCodeActionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/DiagnosticsCodeActionFeature.hx
@@ -1,5 +1,6 @@
 package haxeLanguageServer.features.haxe.codeAction;
 
+import haxe.display.Diagnostic.DiagnosticKind;
 import haxeLanguageServer.features.haxe.DiagnosticsFeature;
 import haxeLanguageServer.features.haxe.codeAction.CodeActionFeature;
 import haxeLanguageServer.features.haxe.codeAction.diagnostics.AddTypeHintActions;
@@ -39,13 +40,13 @@ class DiagnosticsCodeActionFeature implements CodeActionContributor {
 			if (kind == null || !(kind is Int)) { // our codes are int, so we don't handle other stuff
 				continue;
 			}
-			final code = new DiagnosticKind<T>(kind);
+			final code:DiagnosticKind<T> = DiagnosticKindHelper.make(kind);
 			actions = actions.concat(switch code {
-				case UnusedImport: UnusedImportActions.createUnusedImportActions(context, params, diagnostic);
-				case UnresolvedIdentifier: UnresolvedIdentifierActions.createUnresolvedIdentifierActions(context, params, diagnostic);
-				case CompilerError: CompilerErrorActions.createCompilerErrorActions(context, params, diagnostic);
-				case ReplaceableCode: ReplaceableCodeActions.createReplaceableCodeActions(context, params, diagnostic);
-				case ParserError: ParserErrorActions.createParserErrorActions(context, params, diagnostic);
+				case DKUnusedImport: UnusedImportActions.createUnusedImportActions(context, params, diagnostic);
+				case DKUnresolvedIdentifier: UnresolvedIdentifierActions.createUnresolvedIdentifierActions(context, params, diagnostic);
+				case DKCompilerError: CompilerErrorActions.createCompilerErrorActions(context, params, diagnostic);
+				case ReplacableCode: ReplaceableCodeActions.createReplaceableCodeActions(context, params, diagnostic);
+				case DKParserError: ParserErrorActions.createParserErrorActions(context, params, diagnostic);
 				case MissingFields: MissingFieldsActions.createMissingFieldsActions(context, params, diagnostic);
 				case _: [];
 			});

--- a/src/haxeLanguageServer/features/haxe/codeAction/OrganizeImportsFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/OrganizeImportsFeature.hx
@@ -194,8 +194,10 @@ class OrganizeImportsFeature {
 			edits = edits.concat(organizeImportGroup(doc, context, group));
 		}
 
-		if (last != null)
+		if (last != null) {
 			edits = edits.concat(organizeImportGroup(doc, context, last));
+		}
+
 		return edits;
 	}
 

--- a/src/haxeLanguageServer/features/haxe/codeAction/OrganizeImportsFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/OrganizeImportsFeature.hx
@@ -194,7 +194,8 @@ class OrganizeImportsFeature {
 			edits = edits.concat(organizeImportGroup(doc, context, group));
 		}
 
-		if (last != null) edits = edits.concat(organizeImportGroup(doc, context, last));
+		if (last != null)
+			edits = edits.concat(organizeImportGroup(doc, context, last));
 		return edits;
 	}
 

--- a/src/haxeLanguageServer/features/haxe/codeAction/OrganizeImportsFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/OrganizeImportsFeature.hx
@@ -187,9 +187,14 @@ class OrganizeImportsFeature {
 
 	static function organizeImportGroups(doc:HxTextDocument, context:Context, importGroups:Map<Int, ImportGroup>):Array<TextEdit> {
 		var edits:Array<TextEdit> = [];
+		var last = importGroups.get(-1);
+		importGroups.remove(-1);
+
 		for (group in importGroups) {
 			edits = edits.concat(organizeImportGroup(doc, context, group));
 		}
+
+		if (last != null) edits = edits.concat(organizeImportGroup(doc, context, last));
 		return edits;
 	}
 

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/CompilerErrorActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/CompilerErrorActions.hx
@@ -8,7 +8,7 @@ class CompilerErrorActions {
 			return [];
 		}
 		final actions:Array<CodeAction> = [];
-		final arg = context.diagnostics.getArguments(params.textDocument.uri, CompilerError, diagnostic.range);
+		final arg = context.diagnostics.getArguments(params.textDocument.uri, DKCompilerError, diagnostic.range);
 		if (arg == null) {
 			return actions;
 		}

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/MissingFieldsActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/MissingFieldsActions.hx
@@ -1,5 +1,6 @@
 package haxeLanguageServer.features.haxe.codeAction.diagnostics;
 
+import haxe.display.Diagnostic.MissingFieldCause;
 import haxe.display.JsonModuleTypes;
 import haxe.ds.Option;
 import haxe.io.Path;

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/OrganizeImportActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/OrganizeImportActions.hx
@@ -1,6 +1,6 @@
 package haxeLanguageServer.features.haxe.codeAction.diagnostics;
 
-import haxeLanguageServer.features.haxe.DiagnosticsFeature.DiagnosticKind;
+import haxe.display.Diagnostic.DiagnosticKind;
 import haxeLanguageServer.features.haxe.codeAction.CodeActionFeature;
 import haxeLanguageServer.features.haxe.codeAction.OrganizeImportsFeature;
 import haxeLanguageServer.helper.DocHelper;
@@ -29,7 +29,7 @@ class OrganizeImportActions {
 		final map = context.diagnostics.getArgumentsMap(uri);
 		final removeUnusedFixes = if (map == null) [] else [
 			for (key in map.keys()) {
-				if (key.code == DiagnosticKind.UnusedImport) {
+				if (key.code == DiagnosticKind.DKUnusedImport) {
 					WorkspaceEditHelper.removeText(DocHelper.untrimRange(doc, key.range));
 				}
 			}

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ParserErrorActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ParserErrorActions.hx
@@ -9,7 +9,7 @@ class ParserErrorActions {
 			return [];
 		}
 		final actions:Array<CodeAction> = [];
-		final arg = context.diagnostics.getArguments(params.textDocument.uri, ParserError, diagnostic.range);
+		final arg = context.diagnostics.getArguments(params.textDocument.uri, DKParserError, diagnostic.range);
 		if (arg == null) {
 			return actions;
 		}

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ReplaceableCodeActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ReplaceableCodeActions.hx
@@ -5,7 +5,7 @@ class ReplaceableCodeActions {
 		if ((params.context.only != null) && (!params.context.only.contains(QuickFix))) {
 			return [];
 		}
-		final args = context.diagnostics.getArguments(params.textDocument.uri, ReplacableCode, diagnostic.range);
+		final args = context.diagnostics.getArguments(params.textDocument.uri, ReplaceableCode, diagnostic.range);
 		final range = args!.range;
 		final newText = args!.newCode;
 		if (range == null) {

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ReplaceableCodeActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ReplaceableCodeActions.hx
@@ -5,7 +5,7 @@ class ReplaceableCodeActions {
 		if ((params.context.only != null) && (!params.context.only.contains(QuickFix))) {
 			return [];
 		}
-		final args = context.diagnostics.getArguments(params.textDocument.uri, ReplaceableCode, diagnostic.range);
+		final args = context.diagnostics.getArguments(params.textDocument.uri, ReplacableCode, diagnostic.range);
 		final range = args!.range;
 		final newText = args!.newCode;
 		if (range == null) {

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/UnresolvedIdentifierActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/UnresolvedIdentifierActions.hx
@@ -9,16 +9,16 @@ class UnresolvedIdentifierActions {
 		if ((params.context.only != null) && (!params.context.only.contains(QuickFix))) {
 			return [];
 		}
-		final args = context.diagnostics.getArguments(params.textDocument.uri, UnresolvedIdentifier, diagnostic.range);
+		final args = context.diagnostics.getArguments(params.textDocument.uri, DKUnresolvedIdentifier, diagnostic.range);
 		if (args == null) {
 			return [];
 		}
 		var actions:Array<CodeAction> = [];
-		final importCount = args.count(a -> a.kind == Import);
+		final importCount = args.count(a -> a.kind == UISImport);
 		for (arg in args) {
 			actions = actions.concat(switch arg.kind {
-				case Import: createUnresolvedImportActions(context, params, diagnostic, arg, importCount);
-				case Typo: createTypoActions(context, params, diagnostic, arg);
+				case UISImport: createUnresolvedImportActions(context, params, diagnostic, arg, importCount);
+				case UISTypo: createTypoActions(context, params, diagnostic, arg);
 			});
 		}
 		return actions;

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/UpdateSyntaxActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/UpdateSyntaxActions.hx
@@ -1,6 +1,6 @@
 package haxeLanguageServer.features.haxe.codeAction.diagnostics;
 
-import haxeLanguageServer.features.haxe.DiagnosticsFeature.DiagnosticKind;
+import haxe.display.Diagnostic.DiagnosticKind;
 import haxeLanguageServer.features.haxe.codeAction.CodeActionFeature;
 import haxeLanguageServer.helper.DocHelper;
 import haxeLanguageServer.helper.FormatterHelper;

--- a/src/haxeLanguageServer/server/HaxeServer.hx
+++ b/src/haxeLanguageServer/server/HaxeServer.hx
@@ -205,7 +205,6 @@ class HaxeServer {
 		context.callHaxeMethod(ServerMethods.Configure, {
 			noModuleChecks: true,
 			print: context.config.displayServer.print,
-			populateCacheFromDisplay: context.config.user.populateCacheFromDisplay,
 			legacyCompletion: context.config.user.useLegacyCompletion
 		}, null, _ -> null, function(error) {
 			trace("Error during " + ServerMethods.Configure + " " + error);


### PR DESCRIPTION
* Use Json RPC diagnostics if available (added in HaxeFoundation/haxe#11412)
* Removed (undocumented) populateCacheFromDisplay config, which is not needed with Json RPC diagnostics nor with recent nightlies; could technically be useful for older nightlies or 4.3.x but this hack has been removed so it's a bit of a PITA to continue to support it here
* Had to update tests because HaxeFoundation/Haxe#11698 changed iteration order for js maps 
* Added support for diagnostics on all open (Haxe) files in a single diagnostics request; can be disabled by config
  * TODO followup: add support for this config in vshaxe
