### PR TITLE
Special handling for empty Json RPC Diagnostics

### DIFF
--- a/src/haxeLanguageServer/Context.hx
+++ b/src/haxeLanguageServer/Context.hx
@@ -102,6 +102,12 @@ class Context {
 		final includeDisplayArguments = method.startsWith("display/") || method == ServerMethods.ReadClassPaths;
 		callDisplay(method, [Json.stringify(message)], token, function(result:DisplayResult) {
 			switch result {
+				case DResult("") if (method == DisplayMethods.Diagnostics):
+					haxeDisplayProtocol.handleMessage(({
+						jsonrpc: Protocol.PROTOCOL_VERSION,
+						id: @:privateAccess haxeDisplayProtocol.nextRequestId - 1, // ew..
+						result: {result: []}
+					} : ResponseMessage));
 				case DResult(msg):
 					haxeDisplayProtocol.handleMessage(Json.parse(msg));
 				case DCancelled:

--- a/src/haxeLanguageServer/Context.hx
+++ b/src/haxeLanguageServer/Context.hx
@@ -105,7 +105,7 @@ class Context {
 				case DResult("") if (method == DisplayMethods.Diagnostics):
 					haxeDisplayProtocol.handleMessage(({
 						jsonrpc: Protocol.PROTOCOL_VERSION,
-						id: @:privateAccess haxeDisplayProtocol.nextRequestId - 1, // ew..
+						id: (cast message : RequestMessage).id,
 						result: {result: []}
 					} : ResponseMessage));
 				case DResult(msg):


### PR DESCRIPTION
See https://github.com/HaxeFoundation/haxe/issues/11709 (which will be handled, but this will still be necessary for older Haxe nightlies)