### PR TITLE
Improve postfix trace

### DIFF
--- a/src/haxeLanguageServer/features/haxe/completion/PostfixCompletion.hx
+++ b/src/haxeLanguageServer/features/haxe/completion/PostfixCompletion.hx
@@ -55,18 +55,15 @@ class PostfixCompletion {
 		if (expr.startsWith("(") && expr.endsWith(")")) {
 			expr = expr.substring(1, expr.length - 1);
 		}
-		// `;` char in `foo.;` completion cases
-		final afterExprRange:Range = {
-			start: subject.range.end.translate(0, 1),
-			end: subject.range.end.translate(0, 2)
-		}
-		final afterExprChar = data.doc.getText(afterExprRange);
 
 		var replaceRange = data.replaceRange;
 		if (replaceRange == null) {
 			replaceRange = data.params.position.toRange();
 		}
 		final removeRange:Range = {start: subject.range.start, end: replaceRange.start};
+
+		// `;` char in `foo.;` completion cases
+		final afterExprChar = data.doc.characterAt(replaceRange.end);
 
 		final result:Array<CompletionItem> = [];
 		function add(item:PostfixCompletionItem) {
@@ -147,7 +144,7 @@ class PostfixCompletion {
 	}
 
 	function createTraceItem(expr:String, afterExprChar:String, add:PostfixCompletionItem->Void):Void {
-		final endChar = afterExprChar == "\n" ? ";" : "";
+		final endChar = (afterExprChar == ";" || afterExprChar == ")") ? "" : ";";
 		add({
 			label: "trace",
 			detail: 'trace(expr)$endChar',

--- a/src/haxeLanguageServer/features/haxe/completion/PostfixCompletion.hx
+++ b/src/haxeLanguageServer/features/haxe/completion/PostfixCompletion.hx
@@ -55,6 +55,12 @@ class PostfixCompletion {
 		if (expr.startsWith("(") && expr.endsWith(")")) {
 			expr = expr.substring(1, expr.length - 1);
 		}
+		// `;` char in `foo.;` completion cases
+		final afterExprRange:Range = {
+			start: subject.range.end.translate(0, 1),
+			end: subject.range.end.translate(0, 2)
+		}
+		final afterExprChar = data.doc.getText(afterExprRange);
 
 		var replaceRange = data.replaceRange;
 		if (replaceRange == null) {
@@ -125,6 +131,7 @@ class PostfixCompletion {
 		}
 
 		if (level != Filtered) {
+			createTraceItem(expr, afterExprChar, add);
 			createNonFilteredItems(dotPath, expr, add);
 		}
 
@@ -139,6 +146,16 @@ class PostfixCompletion {
 		return result;
 	}
 
+	function createTraceItem(expr:String, afterExprChar:String, add:PostfixCompletionItem->Void):Void {
+		final endChar = afterExprChar == "\n" ? ";" : "";
+		add({
+			label: "trace",
+			detail: 'trace(expr)$endChar',
+			insertText: 'trace($${1:$expr})$endChar',
+			insertTextFormat: Snippet
+		});
+	}
+
 	function createNonFilteredItems(dotPath:Null<DotPath>, expr:String, add:PostfixCompletionItem->Void) {
 		if (dotPath != Std_String) {
 			add({
@@ -149,12 +166,6 @@ class PostfixCompletion {
 			});
 		}
 
-		add({
-			label: "trace",
-			detail: "trace(expr);",
-			insertText: 'trace($${1:$expr});',
-			insertTextFormat: Snippet
-		});
 		// TODO: check if we're on a sys target
 		add({
 			label: "print",

--- a/src/haxeLanguageServer/features/haxe/completion/PostfixCompletion.hx
+++ b/src/haxeLanguageServer/features/haxe/completion/PostfixCompletion.hx
@@ -151,7 +151,7 @@ class PostfixCompletion {
 
 		add({
 			label: "trace",
-			detail: 'trace(expr);',
+			detail: "trace(expr);",
 			insertText: 'trace($${1:$expr});',
 			insertTextFormat: Snippet,
 			eat: ";"
@@ -351,7 +351,7 @@ while (i-- > 0) {
 			final pos = replaceRange.end;
 			var nextChar = doc.characterAt(pos);
 			// if user writes `.l abel` too fast, detect it and check next char again
-			if (nextChar == data.label.charAt(0)) {
+			if (nextChar == data.label.charAt(0) && nextChar != data.eat) {
 				nextChar = doc.characterAt(pos.translate(0, 1));
 			}
 			if (nextChar == data.eat) {


### PR DESCRIPTION
`call().tr<tab>;` currently generates `trace(call());;`, so this fixes such case with semicolon