### PR TITLE
Remove safe navigation macro

### DIFF
--- a/src/haxeLanguageServer/Context.hx
+++ b/src/haxeLanguageServer/Context.hx
@@ -133,7 +133,7 @@ class Context {
 	}
 
 	public function startProgress(title:String):() -> Void {
-		if (capabilities.window!.workDoneProgress == false) {
+		if (capabilities.window?.workDoneProgress == false) {
 			return function() {};
 		}
 		final id = progressId++;
@@ -162,7 +162,7 @@ class Context {
 		}
 		capabilities = params.capabilities;
 		final initOptions:Null<InitOptions> = params.initializationOptions;
-		experimental = initOptions!.experimentalClientCapabilities ?? {};
+		experimental = initOptions?.experimentalClientCapabilities ?? {};
 		config.onInitialize(params);
 		serverRecording.onInitialize(this);
 
@@ -172,8 +172,8 @@ class Context {
 		new ColorProviderFeature(this);
 		new InlayHintFeature(this);
 
-		final textDocument = capabilities!.textDocument;
-		final workspace = capabilities!.workspace;
+		final textDocument = capabilities?.textDocument;
+		final workspace = capabilities?.workspace;
 		final registrations = new Array<Registration>();
 		function register<P, R, PR, E, RO>(method:ProtocolRequestType<P, R, PR, E, RO>, ?registerId:String, ?selector:DocumentSelector, ?registerOptions:RO) {
 			if (registerOptions == null) {
@@ -195,7 +195,7 @@ class Context {
 		};
 
 		final completionTriggerCharacters = [".", "@", ":", " ", ">", "$"];
-		if (textDocument!.completion!.dynamicRegistration == true) {
+		if (textDocument?.completion?.dynamicRegistration == true) {
 			register(CompletionRequest.type, "haxeDocument/completion", {
 				documentSelector: haxeSelector,
 				triggerCharacters: completionTriggerCharacters,
@@ -214,7 +214,7 @@ class Context {
 		}
 
 		final signatureHelpTriggerCharacters = ["(", ","];
-		if (textDocument!.signatureHelp!.dynamicRegistration == true) {
+		if (textDocument?.signatureHelp?.dynamicRegistration == true) {
 			register(SignatureHelpRequest.type, {
 				documentSelector: haxeSelector,
 				triggerCharacters: signatureHelpTriggerCharacters
@@ -225,53 +225,53 @@ class Context {
 			}
 		}
 
-		if (textDocument!.definition!.dynamicRegistration == true) {
+		if (textDocument?.definition?.dynamicRegistration == true) {
 			register(DefinitionRequest.type, haxeSelector);
 		} else {
 			capabilities.definitionProvider = true;
 		}
 
-		if (textDocument!.hover!.dynamicRegistration == true) {
+		if (textDocument?.hover?.dynamicRegistration == true) {
 			register(HoverRequest.type, "haxeDocument/hover", haxeSelector);
 			register(HoverRequest.type, "hxmlDocument/hover", hxmlSelector);
 		} else {
 			capabilities.hoverProvider = true;
 		}
 
-		if (textDocument!.references!.dynamicRegistration == true) {
+		if (textDocument?.references?.dynamicRegistration == true) {
 			register(ReferencesRequest.type, haxeSelector);
 		} else {
 			capabilities.referencesProvider = true;
 		}
 
-		if (textDocument!.documentSymbol!.dynamicRegistration == true) {
+		if (textDocument?.documentSymbol?.dynamicRegistration == true) {
 			register(DocumentSymbolRequest.type, haxeSelector);
 		} else {
 			capabilities.documentSymbolProvider = true;
 		}
 
-		if (workspace!.symbol!.dynamicRegistration == true) {
+		if (workspace?.symbol?.dynamicRegistration == true) {
 			register(WorkspaceSymbolRequest.type, haxeSelector);
 		} else {
 			capabilities.workspaceSymbolProvider = true;
 		}
 
-		if (textDocument!.formatting!.dynamicRegistration == true) {
+		if (textDocument?.formatting?.dynamicRegistration == true) {
 			register(DocumentFormattingRequest.type, haxeSelector);
 		} else {
 			capabilities.documentFormattingProvider = true;
 		}
 
-		if (textDocument!.rangeFormatting!.dynamicRegistration == true) {
+		if (textDocument?.rangeFormatting?.dynamicRegistration == true) {
 			register(DocumentRangeFormattingRequest.type, haxeSelector);
 		} else {
 			capabilities.documentRangeFormattingProvider = true;
 		}
 
-		if (textDocument!.rename!.dynamicRegistration == true) {
+		if (textDocument?.rename?.dynamicRegistration == true) {
 			register(RenameRequest.type, {documentSelector: haxeSelector, prepareProvider: true});
 		} else {
-			if (textDocument!.rename!.prepareSupport == true) {
+			if (textDocument?.rename?.prepareSupport == true) {
 				capabilities.renameProvider = {
 					prepareProvider: true
 				};
@@ -280,20 +280,20 @@ class Context {
 			}
 		}
 
-		if (textDocument!.foldingRange!.dynamicRegistration == true) {
+		if (textDocument?.foldingRange?.dynamicRegistration == true) {
 			register(FoldingRangeRequest.type, haxeSelector);
 		} else {
 			capabilities.foldingRangeProvider = true;
 		}
 
-		if (textDocument!.colorProvider!.dynamicRegistration == true) {
+		if (textDocument?.colorProvider?.dynamicRegistration == true) {
 			// this registration covers both documentColor and colorPresentation
 			register(DocumentColorRequest.type, haxeSelector);
 		} else {
 			capabilities.colorProvider = true;
 		}
 
-		if (textDocument!.inlayHint!.dynamicRegistration == true) {
+		if (textDocument?.inlayHint?.dynamicRegistration == true) {
 			register(InlayHintRequest.type, haxeSelector);
 		} else {
 			capabilities.inlayHintProvider = true;

--- a/src/haxeLanguageServer/features/haxe/GotoDefinitionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/GotoDefinitionFeature.hx
@@ -38,11 +38,11 @@ class GotoDefinitionFeature {
 				locations = [];
 			resolve(locations.map(location -> {
 				final document = getHaxeDocument(location.file.toUri());
-				final tokens = document!.tokens;
+				final tokens = document?.tokens;
 				var previewDeclarationRange = location.range;
 				if (document != null && tokens != null) {
-					final targetToken = tokens!.getTokenAtOffset(document.offsetAt(location.range.start));
-					final pos = targetToken!.parent!.getPos();
+					final targetToken = tokens?.getTokenAtOffset(document.offsetAt(location.range.start));
+					final pos = targetToken?.parent?.getPos();
 					if (pos != null)
 						previewDeclarationRange = document.rangeAt(pos.min, pos.max);
 				}

--- a/src/haxeLanguageServer/features/haxe/InlayHintFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/InlayHintFeature.hx
@@ -58,7 +58,7 @@ class InlayHintFeature {
 		var endPos = doc.offsetAt(params.range.end);
 
 		var inlayHints:Array<InlayHint> = [];
-		var root:Null<TokenTree> = doc!.tokens!.tree;
+		var root:Null<TokenTree> = doc?.tokens?.tree;
 		if (root == null) {
 			return reject.noFittingDocument(uri);
 		}
@@ -292,7 +292,7 @@ class InlayHintFeature {
 		if (pOpen.access().parent().matches(Kwd(KwdNew)).exists()) {
 			return promises;
 		}
-		var pClose:Null<TokenTree> = pOpen.access().firstOf(PClose)!.token;
+		var pClose:Null<TokenTree> = pOpen.access().firstOf(PClose)?.token;
 		if (pClose == null) {
 			return promises;
 		}
@@ -564,11 +564,11 @@ class InlayHintFeature {
 	}
 
 	function buildParameterName<T>(hover:HoverDisplayItemOccurence<T>):Null<String> {
-		return hover.expected!.name!.name;
+		return hover.expected?.name?.name;
 	}
 
 	function buildTypeHint<T>(hover:HoverDisplayItemOccurence<T>):Null<String> {
-		var type = hover.item!.type;
+		var type = hover.item?.type;
 		if (type == null) {
 			return null;
 		}
@@ -576,7 +576,7 @@ class InlayHintFeature {
 	}
 
 	function buildReturnTypeHint<T>(hover:HoverDisplayItemOccurence<T>):Null<String> {
-		var type = hover.item.type!.args!.ret;
+		var type = hover.item.type?.args?.ret;
 		if (type == null) {
 			return null;
 		}

--- a/src/haxeLanguageServer/features/haxe/RenameFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/RenameFeature.hx
@@ -58,7 +58,7 @@ class RenameFeature {
 		final usageContext:refactor.discover.UsageContext = makeUsageContext();
 		usageContext.fileName = filePath.toString();
 
-		var root:Null<TokenTree> = doc!.tokens!.tree;
+		var root:Null<TokenTree> = doc?.tokens?.tree;
 		if (root == null) {
 			usageContext.usageCollector.parseFile(ByteData.ofString(doc.content), usageContext);
 		} else {

--- a/src/haxeLanguageServer/features/haxe/SignatureHelpFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/SignatureHelpFeature.hx
@@ -25,7 +25,7 @@ class SignatureHelpFeature {
 
 	public function new(context:Context) {
 		this.context = context;
-		labelOffsetSupport = context.capabilities.textDocument!.signatureHelp!.signatureInformation!.parameterInformation!.labelOffsetSupport == true;
+		labelOffsetSupport = context.capabilities.textDocument?.signatureHelp?.signatureInformation?.parameterInformation?.labelOffsetSupport == true;
 		context.languageServerProtocol.onRequest(SignatureHelpRequest.type, onSignatureHelp);
 	}
 
@@ -43,7 +43,7 @@ class SignatureHelpFeature {
 			doc:HaxeDocument) {
 		var wasAutoTriggered = true;
 		if (context.haxeServer.haxeVersion >= new SemVer(4, 1, 0)) {
-			final triggerKind = params!.context!.triggerKind;
+			final triggerKind = params?.context?.triggerKind;
 			wasAutoTriggered = switch triggerKind {
 				case null: false; // err on the side of showing too often for LSP clients that don't support triggerKind
 				case TriggerCharacter: true;

--- a/src/haxeLanguageServer/features/haxe/codeAction/CodeActionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/CodeActionFeature.hx
@@ -48,7 +48,7 @@ class CodeActionFeature {
 			],
 			resolveProvider: true
 		});
-		hasCommandResolveSupport = context.capabilities.textDocument!.codeAction!.resolveSupport!.properties!.contains("command") ?? false;
+		hasCommandResolveSupport = context.capabilities.textDocument?.codeAction?.resolveSupport?.properties?.contains("command") ?? false;
 		if (!hasCommandResolveSupport) {
 			hasCommandResolveSupport = context.experimental?.forceCommandResolveSupport ?? false;
 		}
@@ -78,9 +78,9 @@ class CodeActionFeature {
 
 	function onCodeActionResolve(action:CodeAction, token:CancellationToken, resolve:CodeAction->Void, reject:ResponseError<NoData>->Void) {
 		final data:Null<CodeActionResolveData> = action.data;
-		final type = data!.type;
-		final params = data!.params;
-		final diagnostic = data!.diagnostic;
+		final type = data?.type;
+		final params = data?.params;
+		final diagnostic = data?.diagnostic;
 		if (type == null || params == null) {
 			resolve(action);
 			return;

--- a/src/haxeLanguageServer/features/haxe/codeAction/ExtractVarFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/ExtractVarFeature.hx
@@ -72,7 +72,7 @@ class ExtractVarFeature implements CodeActionContributor {
 		while (parent != null) {
 			switch parent.tok {
 				case DblDot: // not anon structure
-					return parent.parent!.parent!.tok != BrOpen;
+					return parent.parent?.parent?.tok != BrOpen;
 				default:
 			}
 			token = parent;
@@ -227,7 +227,7 @@ class ExtractVarFeature implements CodeActionContributor {
 			switch parent.tok {
 				case Dot, QuestionDot:
 					// skip to start of foo.bar.baz
-					if (parent.parent!.isCIdent() == true) {
+					if (parent.parent?.isCIdent() == true) {
 						parent = parent.parent ?? return [];
 					}
 				case DblDot, Binop(_), Kwd(_):
@@ -237,7 +237,7 @@ class ExtractVarFeature implements CodeActionContributor {
 						case _:
 							// end of a.b expr is inside of Dot
 							final first = token.getFirstChild();
-							final hasDot = first!.tok == Dot || first!.tok == QuestionDot;
+							final hasDot = first?.tok == Dot || first?.tok == QuestionDot;
 							final last = hasDot ? first : token;
 							return [token, getLastNonCommaToken(last)];
 					}
@@ -250,7 +250,7 @@ class ExtractVarFeature implements CodeActionContributor {
 					final tokens:Array<Null<TokenTree>> = [token];
 					final firstChild = token.getFirstChild();
 					// don't extract arrow function args
-					if (firstChild!.tok == Arrow || parent.access().firstOf(Arrow) != null)
+					if (firstChild?.tok == Arrow || parent.access().firstOf(Arrow) != null)
 						return [];
 					if (firstChild == null)
 						return tokens;

--- a/src/haxeLanguageServer/features/haxe/codeAction/TokenTreeUtils.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/TokenTreeUtils.hx
@@ -39,9 +39,9 @@ class TokenTreeUtils {
 	public static function isAnonStructure(brToken:TokenTree):Bool {
 		if (brToken.tok == BrClose)
 			brToken = brToken.parent ?? return false;
-		final first = brToken!.getFirstChild() ?? return false;
+		final first = brToken?.getFirstChild() ?? return false;
 		final colon = first.getFirstChild() ?? return false;
-		if (colon.tok.match(DblDot) && !colon.nextSibling!.tok.match(Semicolon)) {
+		if (colon.tok.match(DblDot) && !colon.nextSibling?.tok.match(Semicolon)) {
 			return true;
 		}
 		return false;

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/AddTypeHintActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/AddTypeHintActions.hx
@@ -15,7 +15,7 @@ class AddTypeHintActions {
 		final uri = params.textDocument.uri;
 		final doc = context.documents.getHaxe(uri) ?? return [];
 		final actions:Array<CodeAction> = [];
-		final token = doc.tokens!.getTokenAtOffset(doc.offsetAt(params.range.end));
+		final token = doc.tokens?.getTokenAtOffset(doc.offsetAt(params.range.end));
 		if (token == null)
 			return [];
 
@@ -43,7 +43,7 @@ class AddTypeHintActions {
 			if (!token.tok.match(Kwd(KwdReturn)))
 				return actions;
 
-			final nameToken = token.parent!.parent ?? return actions;
+			final nameToken = token.parent?.parent ?? return actions;
 			// check return type hint
 			if (nameToken.access().firstOf(DblDot) != null)
 				return actions;
@@ -73,7 +73,7 @@ class AddTypeHintActions {
 			return null;
 		var tokenSource = new CancellationTokenSource();
 
-		final identToken = document.tokens!.getTokenAtOffset(document.offsetAt(params.range.end));
+		final identToken = document.tokens?.getTokenAtOffset(document.offsetAt(params.range.end));
 		if (identToken == null)
 			return null;
 
@@ -113,7 +113,7 @@ class AddTypeHintActions {
 			}
 				?? cast return null;
 			final locDoc = context.documents.getHaxe(location.uri) ?? cast return null;
-			final locToken = locDoc.tokens!.getTokenAtOffset(locDoc.offsetAt(location.range.end));
+			final locToken = locDoc.tokens?.getTokenAtOffset(locDoc.offsetAt(location.range.end));
 			if (locToken == null)
 				return null;
 			final child = locToken.getFirstChild();
@@ -135,7 +135,7 @@ class AddTypeHintActions {
 			final hover:HoverDisplayItemOccurence<Dynamic> = results[1];
 			final definition = definitions[0] ?? return action;
 			final defDoc = context.documents.getHaxe(definition.targetUri) ?? return action;
-			final defToken = defDoc.tokens!.getTokenAtOffset(defDoc.offsetAt(definition.targetSelectionRange.end));
+			final defToken = defDoc.tokens?.getTokenAtOffset(defDoc.offsetAt(definition.targetSelectionRange.end));
 			// check if definition already has typehint
 			if (defToken == null || !defToken.isCIdent())
 				return action;

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ChangeFinalToVarAction.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ChangeFinalToVarAction.hx
@@ -16,7 +16,7 @@ class ChangeFinalToVarAction {
 			return null;
 		var tokenSource = new CancellationTokenSource();
 
-		final varToken = document.tokens!.getTokenAtOffset(document.offsetAt(diagnostic.range.start));
+		final varToken = document.tokens?.getTokenAtOffset(document.offsetAt(diagnostic.range.start));
 		if (varToken == null)
 			return null;
 		final gotoPromise = new Promise(function(resolve:(definitions:Array<DefinitionLink>) -> Void, reject) {
@@ -34,7 +34,7 @@ class ChangeFinalToVarAction {
 			final definitionDoc = context.documents.getHaxe(definition.targetUri);
 			if (definitionDoc == null)
 				return action;
-			final varDefinitionToken = definitionDoc.tokens!.getTokenAtOffset(definitionDoc.offsetAt(definition.targetSelectionRange.start));
+			final varDefinitionToken = definitionDoc.tokens?.getTokenAtOffset(definitionDoc.offsetAt(definition.targetSelectionRange.start));
 			final kwdFinal = getFinalKwd(varDefinitionToken) ?? return action;
 			final range = document.rangeAt(kwdFinal.pos.min, kwdFinal.pos.max, Utf8);
 			action.edit = WorkspaceEditHelper.create(definitionDoc, [{range: range, newText: "var"}]);
@@ -44,7 +44,7 @@ class ChangeFinalToVarAction {
 	}
 
 	static function getFinalKwd(token:Null<TokenTree>) {
-		final kwdFinal = token!.parent;
+		final kwdFinal = token?.parent;
 		if (kwdFinal == null)
 			return null;
 		if (!kwdFinal.tok.match(Kwd(KwdFinal)))

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/CompilerErrorActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/CompilerErrorActions.hx
@@ -56,7 +56,7 @@ class CompilerErrorActions {
 			final document = context.documents.getHaxe(params.textDocument.uri);
 			if (document.tokens != null) {
 				// Resolve parent token to add "override" before "function" instead of function name
-				final funPos = document.tokens!.getTokenAtOffset(document.offsetAt(diagnostic.range.start))!.parent!.pos!.min;
+				final funPos = document.tokens?.getTokenAtOffset(document.offsetAt(diagnostic.range.start))?.parent?.pos?.min;
 				if (funPos != null) {
 					pos = document.positionAt(funPos, Utf8);
 				}

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/MissingArgumentsAction.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/MissingArgumentsAction.hx
@@ -22,7 +22,7 @@ class MissingArgumentsAction {
 			return null;
 		final tokenSource = new CancellationTokenSource();
 
-		final argToken = document.tokens!.getTokenAtOffset(document.offsetAt(diagnostic.range.start) + 1);
+		final argToken = document.tokens?.getTokenAtOffset(document.offsetAt(diagnostic.range.start) + 1);
 		if (argToken == null)
 			return null;
 		final funPos = getCallNamePos(document, argToken);
@@ -42,13 +42,13 @@ class MissingArgumentsAction {
 		if (isFunctionInArg(argToken)) {
 			if (isSingleArgArrowFunction(argToken)) {
 				// hover on `->` token
-				hoverPos = argToken.getFirstChild()!.pos!.min ?? hoverPos;
+				hoverPos = argToken.getFirstChild()?.pos?.min ?? hoverPos;
 			} else {
 				// hover on start of arg for better type hint
 				hoverPos = document.offsetAt(diagnostic.range.start);
 			}
 		} else if (argToken.matches(Kwd(KwdNew))) {
-			hoverPos = argToken.getFirstChild()!.pos!.min ?? hoverPos;
+			hoverPos = argToken.getFirstChild()?.pos?.min ?? hoverPos;
 		}
 		final hoverPromise = makeHoverRequest(context, fileName, hoverPos, tokenSource.token);
 
@@ -61,7 +61,7 @@ class MissingArgumentsAction {
 			final definitionDoc = context.documents.getHaxe(definition.targetUri);
 			if (definitionDoc == null)
 				return action;
-			final definitonFunToken = definitionDoc.tokens!.getTokenAtOffset(definitionDoc.offsetAt(definition.targetSelectionRange.start));
+			final definitonFunToken = definitionDoc.tokens?.getTokenAtOffset(definitionDoc.offsetAt(definition.targetSelectionRange.start));
 			final argRange = functionNewArgPos(definitionDoc, definitonFunToken) ?? return action;
 			final hadCommaAtEnd = functionArgsEndsWithComma(definitionDoc, definitonFunToken);
 			var argName = generateArgName(item);
@@ -132,7 +132,7 @@ class MissingArgumentsAction {
 	}
 
 	static function isSingleArgArrowFunction(argToken:TokenTree):Bool {
-		return argToken.isCIdent() && argToken.getFirstChild()!.tok == Arrow;
+		return argToken.isCIdent() && argToken.getFirstChild()?.tok == Arrow;
 	}
 
 	static function generateArgName(item:DisplayItem<Dynamic>):String {
@@ -143,7 +143,7 @@ class MissingArgumentsAction {
 			case ClassField:
 				return item.args?.field?.name ?? "arg";
 			case Expression:
-				if (item.type!.kind == TFun)
+				if (item.type?.kind == TFun)
 					return "callback";
 			case _:
 				return item.args?.name ?? "arg";
@@ -152,7 +152,7 @@ class MissingArgumentsAction {
 	}
 
 	public static function genArgNameFromJsonType(type:Null<JsonType<Dynamic>>):String {
-		final dotPath = type!.getDotPath() ?? return "arg";
+		final dotPath = type?.getDotPath() ?? return "arg";
 		return switch dotPath {
 			case Std_Bool: "bool";
 			case Std_Int, Std_UInt: "i";
@@ -229,14 +229,14 @@ class MissingArgumentsAction {
 		if (funIdent == null)
 			return null;
 		// Check for: var foo:()->Void = ...
-		final isFunction = switch (funIdent!.parent!.tok) {
+		final isFunction = switch (funIdent?.parent?.tok) {
 			case Kwd(KwdFunction): true;
 			case _: false;
 		}
 		if (!isFunction) {
 			funIdent = funIdent.getFirstChild() ?? return null;
 		}
-		final pOpen = funIdent.access().firstOf(POpen)!.token;
+		final pOpen = funIdent.access().firstOf(POpen)?.token;
 		return pOpen;
 	}
 
@@ -245,7 +245,7 @@ class MissingArgumentsAction {
 		if (pOpen == null) {
 			return null;
 		}
-		final pClose = pOpen.access().firstOf(PClose)!.token;
+		final pClose = pOpen.access().firstOf(PClose)?.token;
 		if (pClose == null) {
 			return null;
 		}
@@ -265,7 +265,7 @@ class MissingArgumentsAction {
 
 	static function functionArgsEndsWithComma(document:HaxeDocument, funIdent:Null<TokenTree>):Bool {
 		final pOpen = getFunctionPOpen(funIdent) ?? return false;
-		final maybeComma = pOpen.getLastChild()!.getLastChild();
+		final maybeComma = pOpen.getLastChild()?.getLastChild();
 		if (maybeComma == null) {
 			return false;
 		}

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/MissingFieldsActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/MissingFieldsActions.hx
@@ -139,7 +139,7 @@ class MissingFieldsActions {
 					}
 				} else {
 					final signature = field.type.extractFunctionSignature();
-					final args = signature!.args;
+					final args = signature?.args;
 					if (args != null) {
 						final isSnippetArgs = isSnippet && snippetEditId == -1;
 						// hack to generate ${1:arg} snippet ranges for new function args
@@ -161,7 +161,7 @@ class MissingFieldsActions {
 						if (pos != null)
 							rangeFieldInsertion = pos.toRange();
 					} else {
-						final funToken = tokens!.getTokenAtOffset(document.offsetAt(diagnostic.range.start));
+						final funToken = tokens?.getTokenAtOffset(document.offsetAt(diagnostic.range.start));
 						if (funToken != null) {
 							final pos = getNewClassFunctionPos(document, classToken, funToken);
 							if (pos != null)
@@ -328,7 +328,7 @@ class MissingFieldsActions {
 	}
 
 	static function getNewVariablePos(document:HaxeDocument, classToken:TokenTree, fieldScope:JsonClassFieldScope):Null<Position> {
-		final brOpen = classToken.access().firstChild().firstOf(BrOpen)!.token;
+		final brOpen = classToken.access().firstChild().firstOf(BrOpen)?.token;
 		if (brOpen == null) {
 			return null;
 		}
@@ -338,7 +338,7 @@ class MissingFieldsActions {
 		}
 		// find place for field before first function in class
 		final firstFun = brOpen.access().firstOf(Kwd(KwdFunction));
-		var prev = firstFun!.token!.previousSibling;
+		var prev = firstFun?.token?.previousSibling;
 		while (prev != null && prev.isComment()) {
 			prev = prev.previousSibling;
 		}
@@ -351,7 +351,7 @@ class MissingFieldsActions {
 	}
 
 	static function getNewClassFunctionPos(document:HaxeDocument, classToken:TokenTree, callToken:TokenTree):Null<Position> {
-		final brOpen = classToken.access().firstChild().firstOf(BrOpen)!.token;
+		final brOpen = classToken.access().firstChild().firstOf(BrOpen)?.token;
 		if (brOpen == null) {
 			return null;
 		}

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ParserErrorActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ParserErrorActions.hx
@@ -18,7 +18,7 @@ class ParserErrorActions {
 			final document = context.documents.getHaxe(params.textDocument.uri);
 			final nextText = document.content.substr(document.offsetAt(diagnostic.range.end));
 			final isAuto = nextText.split("{").length == nextText.split("}").length;
-			final token = document!.tokens!.getTokenAtOffset(document.offsetAt(diagnostic.range.end));
+			final token = document?.tokens?.getTokenAtOffset(document.offsetAt(diagnostic.range.end));
 			var range = diagnostic.range;
 			if (token != null) {
 				for (sib in [token.previousSibling, token.nextSibling]) {
@@ -61,7 +61,7 @@ class ParserErrorActions {
 
 		if (arg.contains("Expected }")) {
 			final document = context.documents.getHaxe(params.textDocument.uri);
-			final token = document!.tokens!.getTokenAtOffset(document.offsetAt(diagnostic.range.end));
+			final token = document?.tokens?.getTokenAtOffset(document.offsetAt(diagnostic.range.end));
 			final prevToken = getPrevNonCommentSibling(token);
 			if (prevToken != null && token != null) {
 				final prevToken = getLastNonCommentToken(prevToken);
@@ -156,7 +156,7 @@ class ParserErrorActions {
 		final tokens = document.tokens;
 		if (tokens == null)
 			return null;
-		final errToken = tokens!.getTokenAtOffset(document.offsetAt(errPos));
+		final errToken = tokens?.getTokenAtOffset(document.offsetAt(errPos));
 		if (errToken == null)
 			return null;
 		final prev = getPrevNonCommentSibling(errToken);
@@ -170,8 +170,8 @@ class ParserErrorActions {
 
 	static function getPrevNonCommentSibling(token:Null<TokenTree>):Null<TokenTree> {
 		do {
-			token = token!.previousSibling;
-		} while (token!.isComment() == true);
+			token = token?.previousSibling;
+		} while (token?.isComment() == true);
 		return token;
 	}
 
@@ -194,7 +194,7 @@ class ParserErrorActions {
 		var i = children.length;
 		while (i-- > 0) {
 			final child = children[i];
-			if (child!.isComment() == false)
+			if (child?.isComment() == false)
 				return child;
 		}
 		return null;
@@ -203,9 +203,9 @@ class ParserErrorActions {
 	static function isAnonStructure(brToken:TokenTree):Bool {
 		if (brToken.tok == BrClose)
 			brToken = brToken.parent ?? return false;
-		final first = brToken!.getFirstChild() ?? return false;
+		final first = brToken?.getFirstChild() ?? return false;
 		final colon = first.getFirstChild() ?? return false;
-		if (colon.tok.match(DblDot) && !colon.nextSibling!.tok.match(Semicolon)) {
+		if (colon.tok.match(DblDot) && !colon.nextSibling?.tok.match(Semicolon)) {
 			return true;
 		}
 		return false;

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ReplaceableCodeActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/ReplaceableCodeActions.hx
@@ -6,8 +6,8 @@ class ReplaceableCodeActions {
 			return [];
 		}
 		final args = context.diagnostics.getArguments(params.textDocument.uri, ReplaceableCode, diagnostic.range);
-		final range = args!.range;
-		final newText = args!.newCode;
+		final range = args?.range;
+		final newText = args?.newCode;
 		if (range == null) {
 			return [];
 		}

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/UpdateSyntaxActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/UpdateSyntaxActions.hx
@@ -15,7 +15,7 @@ class UpdateSyntaxActions {
 		final uri = params.textDocument.uri;
 		final doc = context.documents.getHaxe(uri) ?? return [];
 		final actions:Array<CodeAction> = [];
-		final token = doc.tokens!.getTokenAtOffset(doc.offsetAt(params.range.start));
+		final token = doc.tokens?.getTokenAtOffset(doc.offsetAt(params.range.start));
 		if (token == null)
 			return [];
 
@@ -68,11 +68,11 @@ class UpdateSyntaxActions {
 			if (ifVarName != varName)
 				return;
 		}
-		final valueRange = ranges!.value ?? getIfBodyDeadEndRange(doc, ifToken) ?? return;
+		final valueRange = ranges?.value ?? getIfBodyDeadEndRange(doc, ifToken) ?? return;
 		var value = doc.getText(valueRange);
 		if (!value.endsWith(";"))
 			value += ";";
-		final prevValueToken = varIdent.getFirstChild()!.getFirstChild() ?? return;
+		final prevValueToken = varIdent.getFirstChild()?.getFirstChild() ?? return;
 		final prevValueRange = doc.rangeAt(prevValueToken.getPos(), Utf8);
 		final prevValue = doc.getText(prevValueRange);
 		final replaceRange = prevValueRange.union(doc.rangeAt(ifToken.getPos(), Utf8));
@@ -238,7 +238,7 @@ class UpdateSyntaxActions {
 	}
 
 	static function getBlockReturn(brOpen:TokenTree):Null<TokenTree> {
-		final maybeReturn = brOpen.getLastChild()!.previousSibling ?? cast return null;
+		final maybeReturn = brOpen.getLastChild()?.previousSibling ?? cast return null;
 		if (!maybeReturn.tok.match(Kwd(KwdReturn | KwdThrow)))
 			return null;
 		return maybeReturn;
@@ -370,7 +370,7 @@ class UpdateSyntaxActions {
 	}
 
 	static function addTernaryNullCheckAction(context:Context, params:CodeActionParams, actions:Array<CodeAction>, doc:HaxeDocument, questionToken:TokenTree) {
-		final binopToken = questionToken.parent!.parent ?? return;
+		final binopToken = questionToken.parent?.parent ?? return;
 		final ifIdentEnd = binopToken.parent ?? return;
 		final ifIdentStart = preDotToken(ifIdentEnd);
 
@@ -455,7 +455,7 @@ class UpdateSyntaxActions {
 				if (kwdNull.matches(Kwd(KwdNull)) == false)
 					return null;
 				final questionToken = kwdNull.getFirstChild() ?? cast return null;
-				if (questionToken!.matches(Question) == false)
+				if (questionToken?.matches(Question) == false)
 					return null;
 				return questionToken;
 			}
@@ -509,7 +509,7 @@ class UpdateSyntaxActions {
 	}
 
 	static function getSingleLineIfBodyExpr(ifToken:TokenTree):Null<TokenTree> {
-		var ident = ifToken.access().child(1)!.token ?? cast return null;
+		var ident = ifToken.access().child(1)?.token ?? cast return null;
 		if (ident.matches(BrOpen)) {
 			final children = ident.children ?? cast return null;
 			if (children.length > 2) // expr and BrClose

--- a/src/haxeLanguageServer/features/haxe/completion/CompletionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/completion/CompletionFeature.hx
@@ -71,12 +71,12 @@ class CompletionFeature {
 	}
 
 	function checkCapabilities() {
-		final completion = context.capabilities.textDocument!.completion;
-		contextSupport = completion!.contextSupport == true;
-		markdownSupport = completion!.completionItem!.documentationFormat.let(kinds -> kinds.contains(MarkDown)) == true;
-		snippetSupport = completion!.completionItem!.snippetSupport == true;
-		commitCharactersSupport = completion!.completionItem!.commitCharactersSupport == true;
-		deprecatedSupport = completion!.completionItem!.tagSupport!.valueSet.let(tags -> tags.contains(Deprecated)) == true;
+		final completion = context.capabilities.textDocument?.completion;
+		contextSupport = completion?.contextSupport == true;
+		markdownSupport = completion?.completionItem?.documentationFormat.let(kinds -> kinds.contains(MarkDown)) == true;
+		snippetSupport = completion?.completionItem?.snippetSupport == true;
+		commitCharactersSupport = completion?.completionItem?.commitCharactersSupport == true;
+		deprecatedSupport = completion?.completionItem?.tagSupport?.valueSet.let(tags -> tags.contains(Deprecated)) == true;
 	}
 
 	public function onCompletion(params:CompletionParams, token:CancellationToken, resolve:Null<EitherType<Array<CompletionItem>, CompletionList>>->Void,
@@ -146,10 +146,10 @@ class CompletionFeature {
 		final data:Null<CompletionItemData> = item.data;
 		if (!context.haxeServer.supports(DisplayMethods.CompletionItemResolve)
 			|| previousCompletionData == null
-			|| data!.origin == Custom) {
+			|| data?.origin == Custom) {
 			return resolve(item);
 		}
-		final index = data!.index.sure();
+		final index = (data?.index).sure();
 		previousCompletionData.isResolve = true;
 		context.callHaxeMethod(DisplayMethods.CompletionItemResolve, {index: index}, token, function(result) {
 			final resolvedItem = createCompletionItem(index, result.item, previousCompletionData.sure());
@@ -192,7 +192,7 @@ class CompletionFeature {
 		};
 
 		function createCompletionWithoutHaxeResponse() {
-			final token:Null<TokenTree> = doc.tokens!.getTokenAtOffset(doc.offsetAt(replaceRange.start));
+			final token:Null<TokenTree> = doc.tokens?.getTokenAtOffset(doc.offsetAt(replaceRange.start));
 			// disable snippets/keywords completion in unwanted places
 			if (token != null && token.parent != null) {
 				switch token.parent.tok {

--- a/src/haxeLanguageServer/features/haxe/completion/CompletionFeatureLegacy.hx
+++ b/src/haxeLanguageServer/features/haxe/completion/CompletionFeatureLegacy.hx
@@ -51,7 +51,7 @@ class CompletionFeatureLegacy {
 	static final reCaseOrDefault = ~/\b(case|default)\b[^:]*:$/;
 
 	static function isInvalidCompletionPosition(context:Null<CompletionContext>, text:String):Bool {
-		return context!.triggerCharacter == ":" && reCaseOrDefault.match(text);
+		return context?.triggerCharacter == ":" && reCaseOrDefault.match(text);
 	}
 
 	static final reFieldPart = ~/(\.|@(:?))(\w*)$/;

--- a/src/haxeLanguageServer/features/haxe/completion/PostfixCompletion.hx
+++ b/src/haxeLanguageServer/features/haxe/completion/PostfixCompletion.hx
@@ -29,7 +29,7 @@ class PostfixCompletion {
 			return [];
 		}
 		final context = data.params.context;
-		if (context!.triggerKind == TriggerCharacter && context!.triggerCharacter != ".") {
+		if (context?.triggerKind == TriggerCharacter && context?.triggerCharacter != ".") {
 			return [];
 		}
 

--- a/src/haxeLanguageServer/features/haxe/documentSymbols/DocumentSymbolsResolver.hx
+++ b/src/haxeLanguageServer/features/haxe/documentSymbols/DocumentSymbolsResolver.hx
@@ -67,7 +67,7 @@ class DocumentSymbolsResolver {
 
 			switch token.tok {
 				case Kwd(KwdClass):
-					var name = token.getNameToken()!.getName();
+					var name = token.getNameToken()?.getName();
 					if (name == null && token.isTypeMacroClass()) {
 						name = "<macro class>";
 					}

--- a/src/haxeLanguageServer/features/haxe/foldingRange/FoldingRangeResolver.hx
+++ b/src/haxeLanguageServer/features/haxe/foldingRange/FoldingRangeResolver.hx
@@ -15,7 +15,7 @@ class FoldingRangeResolver {
 
 	public function new(document:HaxeDocument, capabilities:Null<TextDocumentClientCapabilities>) {
 		this.document = document;
-		lineFoldingOnly = capabilities!.foldingRange!.lineFoldingOnly == true;
+		lineFoldingOnly = capabilities?.foldingRange?.lineFoldingOnly == true;
 	}
 
 	public function resolve():Array<FoldingRange> {

--- a/src/haxeLanguageServer/features/hxml/HxmlContextAnalyzer.hx
+++ b/src/haxeLanguageServer/features/hxml/HxmlContextAnalyzer.hx
@@ -27,7 +27,7 @@ function analyzeHxmlContext(line:String, pos:Position):HxmlContext {
 	line = line.substring(0, range.end);
 	final parts = ~/\s+/.replace(line.ltrim(), " ").split(" ");
 	function findFlag(word) {
-		return HxmlFlags.flatten().find(f -> f.name == word || f.shortName == word || f.deprecatedNames!.contains(word));
+		return HxmlFlags.flatten().find(f -> f.name == word || f.shortName == word || f.deprecatedNames?.contains(word));
 	}
 	return {
 		element: switch parts {
@@ -35,7 +35,7 @@ function analyzeHxmlContext(line:String, pos:Position):HxmlContext {
 			case [flag]: Flag(findFlag(flag));
 			case [flag, arg]:
 				final flag = findFlag(flag);
-				switch flag!.argument!.kind {
+				switch flag?.argument?.kind {
 					case null: Unknown;
 					case Enum(values): EnumValue(values.find(v -> v.name == arg), values);
 					case Define:
@@ -47,7 +47,7 @@ function analyzeHxmlContext(line:String, pos:Position):HxmlContext {
 							case [define]: Define(findDefine(define));
 							case [define, value]:
 								final define = findDefine(define);
-								final enumValues = define!.getEnumValues();
+								final enumValues = define?.getEnumValues();
 								if (enumValues != null) {
 									EnumValue(enumValues.find(v -> v.name == arg), enumValues);
 								} else {

--- a/src/haxeLanguageServer/features/hxml/data/Defines.hx
+++ b/src/haxeLanguageServer/features/hxml/data/Defines.hx
@@ -17,8 +17,8 @@ abstract Define(DefineData) from DefineData {
 			origin: cast this.origin
 		});
 		final info = DefineVersions[this.name];
-		final since = info!.since;
-		final until = info!.until;
+		final since = info?.since;
+		final until = info?.until;
 		function youAreUsing() {
 			return if (isAvailable(haxeVersion)) '' else ' (you are using $haxeVersion)';
 		}

--- a/src/haxeLanguageServer/server/HaxeConnection.hx
+++ b/src/haxeLanguageServer/server/HaxeConnection.hx
@@ -97,7 +97,7 @@ class SocketConnection extends HaxeConnection {
 	}
 
 	override function send(data:Buffer) {
-		socket!.write(data);
+		socket?.write(data);
 	}
 
 	override function kill() {

--- a/src/haxeLanguageServer/tokentree/PositionAnalyzer.hx
+++ b/src/haxeLanguageServer/tokentree/PositionAnalyzer.hx
@@ -87,7 +87,7 @@ class PositionAnalyzer {
 		}
 
 		function getFieldKind():FieldKind {
-			return switch fieldToken!.tok {
+			return switch fieldToken?.tok {
 				case Kwd(KwdVar): Var;
 				case Kwd(KwdFinal): Final;
 				case Kwd(KwdFunction): Function;

--- a/vshaxe-build.json
+++ b/vshaxe-build.json
@@ -31,7 +31,6 @@
 				},
 				"macros": [
 					"haxeLanguageServer.Init.run()",
-					"Safety.safeNavigation('haxeLanguageServer')",
 					"nullSafety('haxeLanguageServer')"
 				],
 				"deadCodeElimination": "full",

--- a/vshaxe-build.json
+++ b/vshaxe-build.json
@@ -61,9 +61,7 @@
 					"target": "js",
 					"path": "bin/test.js"
 				},
-				"macros": [
-					"Safety.safeNavigation('haxeLanguageServer')"
-				],
+				"macros": [],
 				"deadCodeElimination": "full",
 				"main": "TestMain",
 				"debug": true


### PR DESCRIPTION
Only code change here is `data?.index.sure();` to `(data?.index).sure();` to make `index` non-nullable because of compiler error. Wonder if this is save nav flaw
https://github.com/RealyUniqueName/Safety/blob/8b0fb7e098ee64176a9e0d3697a91f472183a3ba/src/Safety.hx#L26