### PR TITLE
Hide signature help inside callbacks

### DIFF
--- a/src/haxeLanguageServer/features/haxe/codeAction/TokenTreeUtils.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/TokenTreeUtils.hx
@@ -1,6 +1,7 @@
 package haxeLanguageServer.features.haxe.codeAction;
 
 import tokentree.TokenTree;
+import tokentree.utils.TokenTreeCheckUtils;
 
 class TokenTreeUtils {
 	public static function isInFunctionScope(token:TokenTree):Bool {
@@ -23,8 +24,7 @@ class TokenTreeUtils {
 	public static function isCallPOpen(pOpen:TokenTree):Bool {
 		if (pOpen.tok != POpen)
 			return false;
-		final name = pOpen.parent ?? return false;
-		return name.tok.match(Const(CIdent(_)));
+		return TokenTreeCheckUtils.getPOpenType(pOpen) == Call;
 	}
 
 	public static function isFunctionArg(token:TokenTree):Bool {

--- a/src/haxeLanguageServer/features/haxe/codeAction/TokenTreeUtils.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/TokenTreeUtils.hx
@@ -4,7 +4,11 @@ import tokentree.TokenTree;
 
 class TokenTreeUtils {
 	public static function isInFunctionScope(token:TokenTree):Bool {
-		final brOpen = token.parent ?? return false;
+		final token = token.parent ?? return false;
+		return isFunctionBrOpen(token);
+	}
+
+	public static function isFunctionBrOpen(brOpen:TokenTree):Bool {
 		if (brOpen.tok != BrOpen)
 			return false;
 		final name = brOpen.parent ?? return false;
@@ -14,6 +18,13 @@ class TokenTreeUtils {
 		final fun = name.parent ?? return false;
 		// `function name() {}`
 		return fun.tok.match(Kwd(KwdFunction));
+	}
+
+	public static function isCallPOpen(pOpen:TokenTree):Bool {
+		if (pOpen.tok != POpen)
+			return false;
+		final name = pOpen.parent ?? return false;
+		return name.tok.match(Const(CIdent(_)));
 	}
 
 	public static function isFunctionArg(token:TokenTree):Bool {


### PR DESCRIPTION
Solution for https://github.com/HaxeFoundation/haxe/issues/11794, idk if it's better on ide level.

Example for testing:
```haxe
class Main {
	static function main() {
		foo(0, (name, age) -> {});

		foo(0, (name, age) -> {
			final f = (a, b, c) -> {}
			f(1, 2, 3);
		});
	}

	/** Foo **/
	static function foo(
		a:Int,
		?cb:(name:String, age:Int) -> Void,
		?b:Int,
		?c:Int,
	):Void {}
}
```