### PR TITLE
[diagnostics] rel.location can be null

### DIFF
--- a/src/haxeLanguageServer/features/haxe/DiagnosticsFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/DiagnosticsFeature.hx
@@ -220,7 +220,7 @@ class DiagnosticsFeature {
 					message: hxDiag.kind.getMessage(doc, hxDiag.args, range),
 					data: {kind: hxDiag.kind},
 					relatedInformation: hxDiag.relatedInformation?.map(rel -> {
-						location: {
+						location: rel.location == null ? null : {
 							uri: rel.location.file.toUri(),
 							range: rel.location.range,
 						},

--- a/src/haxeLanguageServer/features/haxe/DiagnosticsFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/DiagnosticsFeature.hx
@@ -220,10 +220,10 @@ class DiagnosticsFeature {
 					message: hxDiag.kind.getMessage(doc, hxDiag.args, range),
 					data: {kind: hxDiag.kind},
 					relatedInformation: hxDiag.relatedInformation?.map(rel -> {
-						location: rel.location == null ? null : {
-							uri: rel.location.file.toUri(),
-							range: rel.location.range,
-						},
+						location: Safety.let(rel.location, location -> {
+							uri: location.file.toUri(),
+							range: location.range,
+						}),
 						message: convertIndentation(rel.message, rel.depth)
 					})
 				}


### PR DESCRIPTION
`relatedInformation`'s `location` can be `null`:
* https://github.com/HaxeFoundation/haxe/blob/ddef638/src/context/display/diagnosticsPrinter.ml#L223
* https://github.com/HaxeFoundation/haxe/blob/c850b65/src/core/json/genjson.ml#L117-L121

Should avoid the following:
![image](https://github.com/user-attachments/assets/4d7d868b-0641-4d7c-917c-e54a0f35240c)

Though I didn't have a repro for this atm.

Note: should probably update https://github.com/vshaxe/language-server-protocol-haxe/blob/master/src/languageServerProtocol/Types.hx#L229 too?