### PR TITLE
Fix bad completion with keyword prefixes

### DIFF
--- a/src/haxeLanguageServer/features/haxe/completion/CompletionFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/completion/CompletionFeature.hx
@@ -252,7 +252,17 @@ class CompletionFeature {
 			switch (mode) {
 				// the replaceRanges sent by Haxe are only trustworthy in some cases (https://github.com/HaxeFoundation/haxe/issues/8669)
 				case Metadata | Toplevel if (result.replaceRange != null):
-					replaceRange = result.replaceRange;
+					if (result.replaceRange.start.isEqual(result.replaceRange.end)) {
+						final word = wordPattern.matched(0);
+						// prevent `do<tab>` to complete into `dodownload` field
+						switch word {
+							case "in", "do", "new", "for", "try", "if", "else", "case", "cast", "enum":
+							case _:
+								replaceRange = result.replaceRange;
+						}
+					} else {
+						replaceRange = result.replaceRange;
+					}
 
 				case New | Toplevel | Implements | Extends | TypeHint | TypeRelation:
 					final pathPattern = ~/\w+(\.\w+)*$/;


### PR DESCRIPTION
```
var innerText = 1;
in<tab> // innerText instead of ininnerText
```
Basically this should be a switch with a full `KeywordKind`, but i only added short keyword as most annoying while auto-completing stuff. Some macro to extract all enum fields to array can be used, but maybe this is enough.

I also wonder, do we need a simple `do` keyword completion? It prevents some `do...` fields from being autocompleted.