### PR TITLE
Fix duplicate context with haxe 5

### DIFF
--- a/src/haxeLanguageServer/server/HaxeServer.hx
+++ b/src/haxeLanguageServer/server/HaxeServer.hx
@@ -220,7 +220,11 @@ class HaxeServer {
 		startProgress("Building Cache");
 
 		// see vshaxe/haxe-language-server#44 for explanation
-		final leadingArgs = ["--no-output", "--each", "--no-output", "-D", "message.no-color"];
+		final leadingArgs = ["--no-output", "--each", "--no-output"];
+		if (haxeVersion.major < 5) {
+			leadingArgs.push("-D");
+			leadingArgs.push("message.no-color");
+		}
 
 		process("cache build", leadingArgs.concat(context.config.displayArguments), null, true, null, Processed(function(_) {
 			stopProgress();


### PR DESCRIPTION
Haxe 5 switched from opt-out color with message.no-color to opt-in color with message.color shortly before preview. Now sending message.no-color isn't recognized any more and generate a different signature

Will also handle it at Haxe side (add `message.no-color` as deprecated define that does not alter signature), but this will stil be useful.